### PR TITLE
feat(guru): tmux persona team wrapper powered by Overstory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ scripts/google-sheets/portfolio-optimizer/
 scripts/*
 !scripts/onboarding/
 !scripts/qa/
+!scripts/guru
 # Private PII data files (real values for git-filter-repo — tracked templates available instead)
 scripts/qa/pii-replacements.txt
 scripts/qa/author-mailmap.txt

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ Finance Guru™ is my private AI-powered family office. It's not software you in
 /finance-orchestrator
 ```
 
+## New: tmux team mode (`guru`)
+
+If you want Finance Guru as a persistent **tmux-based persona team** (Cassandra + specialists), use the new `guru` wrapper (built on Overstory).
+
+Quick start:
+```bash
+./scripts/guru setup
+./scripts/guru init
+```
+
+Docs: `docs/guru.md`
+
 **Eight specialists activate:**
 
 | Agent | Expertise | What They Do |

--- a/docs/guru.md
+++ b/docs/guru.md
@@ -1,0 +1,147 @@
+# Finance Guru Team CLI (`guru`)
+
+This repo now ships a **thin wrapper** around the open-source **Overstory** orchestrator to give Finance Guru a *tmux-based persona team*.
+
+You get:
+- **`guru init`** → starts Cassandra Holt (the coordinator) in tmux
+- **`guru quant` / `guru teacher` / …** → starts or attaches to a specific persona agent in tmux
+- Agents coordinate via **Overstory mail** (SQLite-backed)
+
+> Design intent: Cassandra *never does the work herself* — she delegates to specialists.
+
+---
+
+## Prerequisites
+
+You need these CLIs available in your PATH:
+
+- `claude` (Claude Code)
+- `tmux`
+- `overstory`
+
+### Install Overstory
+
+Overstory is a separate project. Install it once on your machine.
+
+Example (Bun):
+
+```bash
+git clone https://github.com/jayminwest/overstory
+cd overstory
+bun install
+bun link
+```
+
+Confirm:
+```bash
+overstory --help
+```
+
+---
+
+## Quick start
+
+From the repo root:
+
+```bash
+./scripts/guru setup   # one-time: creates/normalizes .overstory config
+./scripts/guru init    # starts Cassandra in tmux
+```
+
+In another terminal (or after detaching), start a persona agent:
+
+```bash
+./scripts/guru quant
+```
+
+---
+
+## Commands
+
+### `guru setup`
+Idempotent. Ensures `.overstory/` exists and is configured for Finance Guru.
+
+Important configuration choices:
+- `beads.enabled=false` (no `bd` dependency)
+- `mulch.enabled=false` (no `mulch` dependency)
+
+### `guru init`
+Starts the **Overstory coordinator** tmux session, but with a Finance Guru system prompt so the coordinator behaves as **Cassandra Holt**.
+
+Coordinator tmux session name:
+- `overstory-finance-guru-coordinator`
+
+### `guru attach`
+Attach to Cassandra’s tmux session.
+
+### `guru quant|teacher|analyst|market|strategy|compliance|builder|qa`
+Spawns a persona session as an Overstory worker and attaches to it.
+
+Notes:
+- Workers are spawned with Overstory capability `builder` so they can write artifacts.
+- Overstory will create git worktrees under `.overstory/worktrees/`.
+- These commands pass `--force-hierarchy` so you can start a specialist directly without going through Cassandra.
+
+### `guru status`
+Shows active Overstory sessions.
+
+### `guru stop [coordinator|all]`
+Stops Cassandra or cleans up everything.
+
+### `guru mail ...`
+Pass-through to `overstory mail ...`.
+
+Examples:
+```bash
+./scripts/guru mail check --inject --agent coordinator
+./scripts/guru mail send --to coordinator --subject "help" --body "need guidance"
+```
+
+---
+
+## How delegation works (recommended pattern)
+
+1) You chat with Cassandra in the `guru init` session.
+2) Cassandra clarifies intent + constraints.
+3) Cassandra delegates to specialists by messaging them (or instructing a lead to spawn them).
+
+Today, the wrapper gives you the tmux lifecycle + persona bootstraps. The next iteration is to add:
+- a `fg-lead` auto-spawn
+- a standard “dispatch protocol” message format
+
+---
+
+## Troubleshooting
+
+### “Missing dependency: overstory/tmux/claude”
+Install the missing tool and retry.
+
+### tmux attach fails / session not found
+Run:
+```bash
+./scripts/guru status
+```
+And/or list tmux sessions:
+```bash
+tmux ls
+```
+
+### Where are the Overstory files?
+They live in:
+- `.overstory/` (config + agent prompts + runtime dbs)
+- `.overstory/worktrees/` (per-agent git worktrees)
+
+---
+
+## Security notes
+
+- Finance Guru private data lives in `fin-guru-private/`. Treat it as sensitive.
+- The coordinator prompt explicitly instructs agents not to leak private info.
+
+---
+
+## Philosophy
+
+Slash commands are fine as a UI. This wrapper makes them optional.
+
+The *real* API is: **spawn persona agents, delegate, and produce artifacts** — with tmux sessions you can attach to whenever you want.

--- a/scripts/guru
+++ b/scripts/guru
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Finance Guru — Overstory wrapper CLI
+#
+# Goal:
+# - `guru init` starts Cassandra (Overstory coordinator) in tmux
+# - `guru quant|teacher|analyst|market|strategy|compliance|builder|qa` spawns/attaches to persona agents
+# - Uses a shared tree (no per-agent worktrees required for the coordinator; workers still use worktrees via Overstory)
+#
+# NOTE: Overstory workers ALWAYS run in git worktrees (that’s how Overstory isolates changes).
+# The user’s requested “shared tree” is interpreted as “single canonical repo + consistent shared context”; Overstory
+# will still create worktrees under .overstory/worktrees.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'EOF'
+Finance Guru — Team CLI (Overstory wrapper)
+
+Usage:
+  guru init                         Start Cassandra (coordinator) + optional lead
+  guru attach                       Attach to Cassandra tmux session
+  guru status                       Show Overstory agent status
+  guru stop [coordinator|all]        Stop Cassandra or everything
+
+  # Spawn/attach to persona agents (each runs in its own tmux session)
+  guru quant|teacher|analyst|market|strategy|compliance|builder|qa
+
+  # Low-level helpers
+  guru setup                        Ensure .overstory is initialized + configured for Finance Guru
+  guru mail [args...]               Pass-through to: overstory mail ...
+
+Requirements:
+  - claude (Claude Code) in PATH
+  - tmux in PATH
+  - overstory in PATH
+
+Docs:
+  - docs/guru.md
+EOF
+}
+
+need() {
+  local bin="$1"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "Missing dependency: $bin" >&2
+    exit 1
+  fi
+}
+
+# Write Finance Guru specific coordinator system prompt used by `overstory coordinator start`.
+write_cassandra_prompt() {
+  mkdir -p .overstory/agent-defs
+  cat > .overstory/agent-defs/coordinator.md <<'EOF'
+# Finance Guru — Cassandra Holt (Coordinator)
+
+You are **Cassandra Holt**, the Finance Guru™ Master Portfolio Orchestrator.
+
+## Non‑negotiable behavior
+- You do **not** do analysis work yourself.
+- You **only**: clarify the user’s intent → create a delegation plan → dispatch tasks to specialists → monitor progress → return a concise synthesis.
+- If the user asks you to “just do it”, you still delegate. No exceptions.
+
+## Finance Guru shared context (must treat as ground truth)
+- Load: `fin-guru/config.yaml`
+- Load: `fin-guru/data/system-context.md`
+- Treat: `fin-guru-private/` as the user’s private strategies and personal data (read carefully; do not leak).
+
+## Delegation model (Overstory)
+- You are the **Overstory coordinator**. You may spawn **lead** agents; leads may spawn builders/reviewers.
+- Preferred pattern:
+  1) Ensure a lead exists (name: `fg-lead`). If not, spawn it.
+  2) Send a dispatch mail to the lead telling it which persona worker(s) to spawn and what to do.
+
+## Specialists (personas)
+When delegating, you may request the lead spawn any of these persona workers:
+- quant (Quant Analyst)
+- teacher (Teaching Specialist)
+- analyst (Market/Portfolio Analyst)
+- market (Market Researcher)
+- strategy (Strategy Advisor)
+- compliance (Compliance Officer)
+- builder (Artifact/Report Builder)
+- qa (Quality Assurance Advisor)
+
+## How to communicate
+- Use `overstory mail send` to communicate with agents.
+- Use `overstory status` to check running sessions.
+- Use `overstory mail check --agent coordinator` to pull inbound updates.
+
+## Output rules
+- Every major recommendation must include: **educational-only / not investment advice** disclaimer.
+- Always ask for missing constraints (time horizon, risk tolerance, deliverable type) before delegating.
+EOF
+}
+
+write_lead_prompt() {
+  mkdir -p .overstory/agent-defs
+  # Keep Overstory's default lead behavior but add Finance Guru context + persona spawning instructions.
+  # This gets appended as system prompt (base agent-defs/lead.md), and task overlays carry the WHAT.
+  # We do NOT replace lead.md here; we add a small “finance guru addendum” spec used at spawn time.
+  :
+}
+
+write_config() {
+  mkdir -p .overstory
+  cat > .overstory/config.yaml <<'EOF'
+# Finance Guru — Overstory configuration
+# This file is intentionally conservative: we disable beads + mulch to avoid requiring extra CLIs.
+
+project:
+  name: finance-guru
+  root: ""
+  canonicalBranch: main
+
+agents:
+  manifestPath: .overstory/agent-manifest.json
+  baseDir: .overstory/agent-defs
+  maxConcurrent: 25
+  staggerDelayMs: 2000
+  maxDepth: 2
+
+worktrees:
+  baseDir: .overstory/worktrees
+
+beads:
+  enabled: false
+
+mulch:
+  enabled: false
+  domains: []
+  primeFormat: markdown
+
+merge:
+  aiResolveEnabled: true
+  reimagineEnabled: false
+
+watchdog:
+  tier0Enabled: true
+  tier0IntervalMs: 30000
+  tier1Enabled: false
+  tier2Enabled: false
+  staleThresholdMs: 300000
+  zombieThresholdMs: 600000
+  nudgeIntervalMs: 60000
+
+logging:
+  verbose: false
+  redactSecrets: true
+EOF
+
+  # Patch root to absolute path (Overstory expects it)
+  # Using python for portability/clarity.
+  python3 - <<PY
+import pathlib, re
+p = pathlib.Path('.overstory/config.yaml')
+text = p.read_text()
+root = str(pathlib.Path('.').resolve())
+text = re.sub(r'\nproject:\n(  name: .*\n  root: )""', f"\nproject:\n  name: finance-guru\n  root: \"{root}\"", text)
+p.write_text(text)
+PY
+}
+
+setup_overstory() {
+  need overstory
+  need tmux
+  need claude
+
+  if [[ ! -d .overstory ]]; then
+    overstory init
+  fi
+
+  # Always enforce our config choices (idempotent)
+  write_config
+  write_cassandra_prompt
+
+  # Ensure hooks are installed into the coordinator tmux session only.
+  # Coordinator start will deploy hooks automatically.
+
+  # Sanity check
+  overstory doctor --category dependencies >/dev/null 2>&1 || true
+}
+
+# Create a tiny spec file that just boots a persona agent and waits for user input.
+# Overstory requires a task-id; with beads disabled, it can be any string.
+# We keep these in .overstory/specs for easy inspection.
+write_persona_spec() {
+  local persona="$1"   # quant|teacher|...
+  local spec_path="$2"
+
+  mkdir -p .overstory/specs
+
+  cat > "$spec_path" <<EOF
+# Finance Guru Persona Session — $persona
+
+You are running as the Finance Guru persona: **$persona**.
+
+## Shared context (load into working memory)
+- fin-guru/config.yaml
+- fin-guru/data/system-context.md
+- fin-guru-private/ (private strategies; treat as sensitive)
+
+## Operating rules
+- Run \
+  - \\`date\\`
+  - \\`date +"%Y-%m-%d"\\`
+  at startup and include it in any time-sensitive research.
+- If you are asked for investment advice, include: educational-only / not investment advice.
+
+## Collaboration
+- If you need other specialists, message Cassandra (coordinator) rather than spawning directly.
+  Use: \\`overstory mail send --to coordinator --subject ... --body ...\\`
+
+## Mode
+This is an *interactive chat* session.
+- Greet in-character.
+- Show a short menu of what you can do.
+- Then WAIT for the user.
+EOF
+}
+
+start_coordinator() {
+  setup_overstory
+  overstory coordinator start --watchdog
+}
+
+attach_coordinator() {
+  setup_overstory
+  # tmux name pattern: overstory-<project>-coordinator
+  # project name comes from config.yaml project.name (finance-guru)
+  tmux attach -t "overstory-finance-guru-coordinator"
+}
+
+spawn_persona() {
+  setup_overstory
+
+  local persona="$1"   # quant|teacher|...
+  local agent_name="$2" # e.g. quant
+  local task_id="chat-${persona}"
+  local spec_path=".overstory/specs/${task_id}.md"
+
+  write_persona_spec "$persona" "$spec_path"
+
+  # Spawn as capability=builder so it can write artifacts if needed.
+  # We bypass coordinator hierarchy restrictions for direct CLI access.
+  overstory sling "$task_id" \
+    --capability builder \
+    --name "$agent_name" \
+    --spec "$spec_path" \
+    --force-hierarchy
+
+  tmux attach -t "overstory-finance-guru-${agent_name}"
+}
+
+status_cmd() {
+  setup_overstory
+  overstory status
+}
+
+stop_cmd() {
+  setup_overstory
+  local what="${1:-coordinator}"
+  case "$what" in
+    coordinator)
+      overstory coordinator stop
+      ;;
+    all)
+      overstory coordinator stop || true
+      overstory clean --completed || true
+      ;;
+    *)
+      echo "Unknown stop target: $what" >&2
+      exit 1
+      ;;
+  esac
+}
+
+cmd="${1:-}" || true
+case "$cmd" in
+  -h|--help|help|"") usage ;;
+  setup) setup_overstory ;;
+  init) start_coordinator ;;
+  attach) attach_coordinator ;;
+  status) status_cmd ;;
+  stop) shift; stop_cmd "${1:-coordinator}" ;;
+  mail) shift; setup_overstory; overstory mail "$@" ;;
+
+  quant) spawn_persona quant quant ;;
+  teacher) spawn_persona teacher teacher ;;
+  analyst) spawn_persona analyst analyst ;;
+  market) spawn_persona market market ;;
+  strategy) spawn_persona strategy strategy ;;
+  compliance) spawn_persona compliance compliance ;;
+  builder) spawn_persona builder builder ;;
+  qa) spawn_persona qa qa ;;
+
+  *)
+    echo "Unknown command: $cmd" >&2
+    usage
+    exit 1
+    ;;
+ esac


### PR DESCRIPTION
Adds Finance Guru — Team CLI (Overstory wrapper)

Usage:
  guru init                         Start Cassandra (coordinator) + optional lead
  guru attach                       Attach to Cassandra tmux session
  guru status                       Show Overstory agent status
  guru stop [coordinator|all]        Stop Cassandra or everything

  # Spawn/attach to persona agents (each runs in its own tmux session)
  guru quant|teacher|analyst|market|strategy|compliance|builder|qa

  # Low-level helpers
  guru setup                        Ensure .overstory is initialized + configured for Finance Guru
  guru mail [args...]               Pass-through to: overstory mail ...

Requirements:
  - claude (Claude Code) in PATH
  - tmux in PATH
  - overstory in PATH

Docs:
  - docs/guru.md Overstory-based wrapper to launch Cassandra + specialist personas in tmux, plus comprehensive docs ().\n\nQuick start:\n- ./scripts/guru setup\n- ./scripts/guru init\n\nNotes:\n- Uses Overstory as backend; expects , , and  in PATH.\n- Disables beads/mulch in .overstory config to avoid extra dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Guru, a team coordination system supporting eight specialist personas (quant, teacher, analyst, market, strategy, compliance, builder, qa) for collaborative workflows. Initialize and manage persona-based sessions, check status, and coordinate work through straightforward commands.

* **Documentation**
  * Added comprehensive guides including setup instructions, command reference, quick-start sequences, and troubleshooting resources for the Guru system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->