### PR TITLE
fix(ci): stabilize release workflow when release token is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,20 +23,17 @@ jobs:
     steps:
       - name: Run release-please
         id: release
+        if: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
         uses: googleapis/release-please-action@v4
         with:
           release-type: python
-          package-name: family-office
-          bump-minor-pre-major: true
-          bump-patch-for-minor-pre-major: true
-          changelog-types: |
-            [
-              {"type":"feat","section":"Added","hidden":false},
-              {"type":"fix","section":"Fixed","hidden":false},
-              {"type":"chore","section":"Changed","hidden":false},
-              {"type":"docs","section":"Documentation","hidden":false},
-              {"type":"security","section":"Security","hidden":false}
-            ]
+          target-branch: main
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Skip release-please when token is not configured
+        if: ${{ secrets.RELEASE_PLEASE_TOKEN == '' }}
+        run: |
+          echo "::notice::RELEASE_PLEASE_TOKEN is not configured; skipping release-please to avoid branch protection failure."
 
   deploy-notes:
     name: Deploy release notes


### PR DESCRIPTION
### Motivation
- Prevent the Release workflow from failing due to unsupported `release-please` inputs and Actions permission limitations. 
- Avoid hard CI failures on repositories where the default `GITHUB_TOKEN` is not permitted to open or approve PRs by requiring an explicit bot/PAT.

### Description
- Update `.github/workflows/release.yml` to remove unsupported/fragile `release-please` inputs and explicitly target `main` via `target-branch: main`.
- Require `RELEASE_PLEASE_TOKEN` for `googleapis/release-please-action@v4` by adding `if: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}` and passing `token: ${{ secrets.RELEASE_PLEASE_TOKEN }}`.
- Add a fallback step that emits a notice and skips running `release-please` when `RELEASE_PLEASE_TOKEN` is not configured to avoid branch-protection/PR permission failures.

### Testing
- Ran a YAML parse/assert using `python` to load `.github/workflows/release.yml` and verify `jobs.release-please.steps[0].with.token == '${{ secrets.RELEASE_PLEASE_TOKEN }}'`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e596cd3b788327bcda613e8c4f2119)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration to require explicit authentication. Release process will now emit a notice when authentication credentials are not properly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->