### PR TITLE
fix(ci): prevent release workflow hard-fail when release token is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,36 @@ jobs:
     name: Release Please — automated release + publish PRs
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      release_created: ${{ steps.release.outputs.release_created || 'false' }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Check release token availability
+        id: token
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -n "${RELEASE_PLEASE_TOKEN}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run release-please
+        if: steps.token.outputs.available == 'true'
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          # Prefer a PAT when available to avoid repository-level restrictions
-          # on pull request creation from the default GITHUB_TOKEN.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          # Use a PAT so release-please can create PRs even when the repository
+          # disables PR creation for the default GITHUB_TOKEN.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Skip release-please when token is missing
+        if: steps.token.outputs.available != 'true'
+        run: |
+          echo "::warning::RELEASE_PLEASE_TOKEN is not configured. Skipping release-please to avoid a hard workflow failure."
+          echo "Release Please skipped: configure RELEASE_PLEASE_TOKEN or enable GitHub Actions PR creation in repository settings." >> "$GITHUB_STEP_SUMMARY"
 
   deploy-notes:
     name: Deploy release notes


### PR DESCRIPTION
### Motivation
- The release workflow could hard-fail when `release-please` attempted to create PRs with the default token while repository settings disallow Actions-created PRs, which caused runs like `24860831293` to fail.

### Description
- Default `release_created` output now falls back to `'false'` to avoid undefined downstream conditions.
- Added a `Check release token availability` step that sets `steps.token.outputs.available` based on `secrets.RELEASE_PLEASE_TOKEN`.
- Made the `Run release-please` step conditional on the token and removed the `github.token` fallback so `release-please` only runs with an explicit PAT.
- Added a `Skip release-please when token is missing` step that emits a workflow warning and writes setup guidance to `GITHUB_STEP_SUMMARY` instead of failing the job.

### Testing
- Validated the modified workflow YAML with `yaml.safe_load`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea959dc1a88327b824889706872a93)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal release automation process by adding token validation and configuration enhancements to ensure reliable and secure release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->