### PR TITLE
AOJ-458: Add buy-ticket smoke scaffold

### DIFF
--- a/apps/buy-ticket-agent/README.md
+++ b/apps/buy-ticket-agent/README.md
@@ -1,0 +1,16 @@
+# Buy-Ticket Agent
+
+Private scaffold for the shadow-mode buy-ticket workflow.
+
+Run the smoke path from the repository root:
+
+```bash
+uv run python -m buy_ticket_agent.main --smoke
+```
+
+The smoke path writes a draft, writes a run log, initializes local SQLite state,
+and sends a short notification when ntfy configuration is available.
+
+The Layer 3 smoke step uses the existing ITC CLI. It runs the credential-free
+capability path when analysis credentials are absent, and switches to a single
+risk probe when those credentials are configured.

--- a/buy_ticket_agent/__init__.py
+++ b/buy_ticket_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Buy-ticket agent smoke scaffold."""
+
+from buy_ticket_agent.pipeline import run_smoke
+
+__all__ = ["run_smoke"]

--- a/buy_ticket_agent/config.py
+++ b/buy_ticket_agent/config.py
@@ -1,0 +1,53 @@
+"""Configuration helpers for the buy-ticket agent smoke path."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SmokePaths(BaseModel):
+    """Filesystem destinations used by the smoke path."""
+
+    model_config = ConfigDict(frozen=True)
+
+    project_root: Path
+    drafts_dir: Path
+    runs_dir: Path
+    state_db: Path
+
+    @classmethod
+    def from_project_root(cls, project_root: Path | None = None) -> SmokePaths:
+        """Build default smoke output paths from the repository root."""
+        root = project_root or Path.cwd()
+        return cls(
+            project_root=root,
+            drafts_dir=root
+            / "fin-guru-private"
+            / "fin-guru"
+            / "tickets"
+            / "auto-drafts",
+            runs_dir=root / "notebooks" / "auto-tickets" / "runs",
+            state_db=root / "notebooks" / "auto-tickets" / "state.db",
+        )
+
+
+class NotificationConfig(BaseModel):
+    """ntfy configuration resolved from environment and Bitwarden."""
+
+    model_config = ConfigDict(frozen=True)
+
+    server_url: str
+    topic: str
+    source: str
+
+
+def get_env(name: str, default: str | None = None) -> str | None:
+    """Return an environment variable after trimming empty values."""
+    value = os.getenv(name, default)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None

--- a/buy_ticket_agent/main.py
+++ b/buy_ticket_agent/main.py
@@ -1,0 +1,48 @@
+"""Command entry point for the buy-ticket agent scaffold."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from buy_ticket_agent.pipeline import run_smoke_for_cli
+from buy_ticket_agent.secrets import SecretAccessError
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(
+        description="Run buy-ticket agent scaffold commands.",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run the scaffold smoke path and write draft/log/state artifacts.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Execute the buy-ticket agent CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.smoke:
+        parser.print_help()
+        return 2
+
+    try:
+        result = run_smoke_for_cli(project_root=Path.cwd())
+    except SecretAccessError as exc:
+        print(f"Secret access blocker: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    return 0 if result.status == "completed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/buy_ticket_agent/notifier.py
+++ b/buy_ticket_agent/notifier.py
@@ -1,0 +1,55 @@
+"""ntfy notification client for buy-ticket smoke tickets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import quote
+
+import requests
+
+from buy_ticket_agent.config import NotificationConfig
+
+
+@dataclass(frozen=True)
+class NotificationResult:
+    """Result envelope for a notification attempt."""
+
+    status: str
+    source: str | None
+    error: str | None = None
+
+
+def push_ticket_preview(
+    config: NotificationConfig | None,
+    *,
+    ticket_id: str,
+    preview: str,
+    timeout: int = 10,
+) -> NotificationResult:
+    """Push a short ticket preview to ntfy.
+
+    The topic is used only to construct the request URL and is never returned.
+    """
+    if config is None:
+        return NotificationResult(status="skipped", source=None)
+
+    url = f"{config.server_url}/{quote(config.topic, safe='')}"
+    headers = {
+        "Title": "Buy-ticket smoke draft",
+        "Tags": "chart_with_upwards_trend",
+        "Priority": "default",
+    }
+    body = f"{ticket_id}: {preview}"
+
+    try:
+        response = requests.post(
+            url, data=body.encode("utf-8"), headers=headers, timeout=timeout
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        return NotificationResult(
+            status="failed",
+            source=config.source,
+            error=exc.__class__.__name__,
+        )
+    return NotificationResult(status="sent", source=config.source)

--- a/buy_ticket_agent/pipeline.py
+++ b/buy_ticket_agent/pipeline.py
@@ -1,0 +1,259 @@
+"""Smoke pipeline for the buy-ticket agent scaffold."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from buy_ticket_agent.config import SmokePaths
+from buy_ticket_agent.notifier import NotificationResult, push_ticket_preview
+from buy_ticket_agent.secrets import resolve_notification_config
+from buy_ticket_agent.state import (
+    initialize_state,
+    record_smoke_failure,
+    record_smoke_run,
+)
+
+SMOKE_TICKER = "SPY"
+ITC_PROXY_TICKER = "SP500"
+DISCLAIMER = (
+    "For educational purposes only; not investment advice. Consult a licensed "
+    "financial professional before acting. Loss of principal is possible."
+)
+
+
+@dataclass(frozen=True)
+class CliEnvelope:
+    """Captured result from the Layer 3 smoke CLI call."""
+
+    command: list[str]
+    status: str
+    returncode: int
+    stdout_chars: int
+    stderr_chars: int
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class SmokeResult:
+    """Result envelope returned by a smoke run."""
+
+    run_id: str
+    ticket_id: str | None
+    status: str
+    draft_path: str | None
+    log_path: str
+    state_db: str
+    notification: NotificationResult | None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _output_length(output: str | bytes | None) -> int:
+    if output is None:
+        return 0
+    return len(output)
+
+
+def run_layer3_smoke_cli(project_root: Path) -> CliEnvelope:
+    """Invoke the existing ITC Risk CLI once for the smoke path."""
+    command_args = (
+        [
+            ITC_PROXY_TICKER,
+            "--universe",
+            "tradfi",
+            "--output",
+            "json",
+            "--no-price",
+        ]
+        if os.getenv("ITC_API_KEY")
+        else ["--list-supported", "tradfi"]
+    )
+    run_command = [sys.executable, "src/analysis/itc_risk_cli.py", *command_args]
+    logged_command = ["python", *run_command[1:]]
+    try:
+        result = subprocess.run(
+            run_command,
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return CliEnvelope(
+            command=logged_command,
+            status="failed",
+            returncode=-1,
+            stdout_chars=_output_length(exc.stdout),
+            stderr_chars=_output_length(exc.stderr),
+            error="TimeoutExpired",
+        )
+    except FileNotFoundError:
+        return CliEnvelope(
+            command=logged_command,
+            status="failed",
+            returncode=-1,
+            stdout_chars=0,
+            stderr_chars=0,
+            error="FileNotFoundError",
+        )
+    status = "succeeded" if result.returncode == 0 else "failed"
+    return CliEnvelope(
+        command=logged_command,
+        status=status,
+        returncode=result.returncode,
+        stdout_chars=_output_length(result.stdout),
+        stderr_chars=_output_length(result.stderr),
+    )
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _make_ticket_payload(
+    *,
+    run_id: str,
+    ticket_id: str,
+    created_at: str,
+    cli_result: CliEnvelope,
+) -> dict:
+    return {
+        "id": ticket_id,
+        "run_id": run_id,
+        "created_at": created_at,
+        "mode": "shadow",
+        "ticker": SMOKE_TICKER,
+        "analysis_proxy": ITC_PROXY_TICKER,
+        "status": "draft",
+        "action": "review_only",
+        "summary": "Smoke draft generated from a single Layer 3 CLI call.",
+        "layer3": {
+            "tool": "itc_risk_cli",
+            "status": cli_result.status,
+            "returncode": cli_result.returncode,
+        },
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def run_smoke(project_root: Path | None = None) -> SmokeResult:
+    """Run the AOJ-458 end-to-end smoke path."""
+    paths = SmokePaths.from_project_root(project_root)
+    now = _utc_now()
+    created_at = now.isoformat()
+    run_id = f"smoke-{now:%Y%m%d}-{uuid4().hex[:8]}"
+    ticket_id = f"ticket-{run_id}"
+
+    notification_config = resolve_notification_config()
+    initialize_state(paths.state_db)
+    cli_result = run_layer3_smoke_cli(paths.project_root)
+
+    draft_path = paths.drafts_dir / f"{run_id}.json"
+    log_path = paths.runs_dir / f"{run_id}.json"
+    preview = f"{SMOKE_TICKER} shadow draft ready for review"
+
+    if cli_result.status != "succeeded":
+        status = "layer3_failed"
+        log_payload = {
+            "event": "buy_ticket_smoke_run",
+            "run_id": run_id,
+            "ticket_id": None,
+            "created_at": created_at,
+            "status": status,
+            "draft_path": None,
+            "state_db": _relative(paths.state_db, paths.project_root),
+            "layer3": asdict(cli_result),
+            "notification": None,
+        }
+        _write_json(log_path, log_payload)
+        record_smoke_failure(
+            paths.state_db,
+            run_id=run_id,
+            created_at=created_at,
+            status=status,
+            log_path=log_path,
+        )
+        return SmokeResult(
+            run_id=run_id,
+            ticket_id=None,
+            status=status,
+            draft_path=None,
+            log_path=_relative(log_path, paths.project_root),
+            state_db=_relative(paths.state_db, paths.project_root),
+            notification=None,
+        )
+
+    ticket_payload = _make_ticket_payload(
+        run_id=run_id,
+        ticket_id=ticket_id,
+        created_at=created_at,
+        cli_result=cli_result,
+    )
+    _write_json(draft_path, ticket_payload)
+
+    notification = push_ticket_preview(
+        notification_config,
+        ticket_id=ticket_id,
+        preview=preview,
+    )
+    status = (
+        "completed"
+        if notification.status in {"sent", "skipped"}
+        else "notification_failed"
+    )
+
+    log_payload = {
+        "event": "buy_ticket_smoke_run",
+        "run_id": run_id,
+        "ticket_id": ticket_id,
+        "created_at": created_at,
+        "status": status,
+        "draft_path": _relative(draft_path, paths.project_root),
+        "state_db": _relative(paths.state_db, paths.project_root),
+        "layer3": asdict(cli_result),
+        "notification": asdict(notification),
+    }
+    _write_json(log_path, log_payload)
+    record_smoke_run(
+        paths.state_db,
+        run_id=run_id,
+        ticket_id=ticket_id,
+        created_at=created_at,
+        ticker=SMOKE_TICKER,
+        status=status,
+        draft_path=draft_path,
+        log_path=log_path,
+        preview=preview,
+    )
+
+    return SmokeResult(
+        run_id=run_id,
+        ticket_id=ticket_id,
+        status=status,
+        draft_path=_relative(draft_path, paths.project_root),
+        log_path=_relative(log_path, paths.project_root),
+        state_db=_relative(paths.state_db, paths.project_root),
+        notification=notification,
+    )
+
+
+def run_smoke_for_cli(project_root: Path | None = None) -> SmokeResult:
+    """CLI wrapper that surfaces BWS access failures to the caller."""
+    return run_smoke(project_root=project_root)

--- a/buy_ticket_agent/secrets.py
+++ b/buy_ticket_agent/secrets.py
@@ -1,0 +1,77 @@
+"""Bitwarden Secrets Manager integration for buy-ticket agent secrets."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from buy_ticket_agent.config import NotificationConfig, get_env
+
+
+class SecretAccessError(RuntimeError):
+    """Raised when a required Bitwarden secret cannot be retrieved."""
+
+
+def get_bws_secret_value(secret_id: str) -> str:
+    """Read a secret value through the Bitwarden Secrets Manager CLI.
+
+    Secret values are never printed by this function. The caller receives only
+    the parsed value field from the BWS JSON response.
+    """
+    command = ["bws", "secret", "get", secret_id, "--output", "json"]
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ) as exc:
+        raise SecretAccessError(
+            "bws secret get failed for the configured ntfy topic secret."
+        ) from exc
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise SecretAccessError("bws secret get returned invalid JSON.") from exc
+
+    value = payload.get("value")
+    if not isinstance(value, str) or not value.strip():
+        raise SecretAccessError("bws secret get did not return a usable value.")
+    return value.strip()
+
+
+def resolve_notification_config() -> NotificationConfig | None:
+    """Resolve ntfy configuration.
+
+    Preferred path is Bitwarden via a configured secret id. `NTFY_TOPIC` remains
+    supported for local smoke runs and tests when no BWS secret id is configured.
+    """
+    server_url = get_env("BUY_TICKET_AGENT_NTFY_URL") or get_env("NTFY_URL")
+    if server_url is None:
+        server_url = "https://ntfy.sh"
+
+    secret_id = get_env("BUY_TICKET_AGENT_NTFY_TOPIC_SECRET_ID") or get_env(
+        "NTFY_TOPIC_SECRET_ID"
+    )
+    if secret_id is not None:
+        return NotificationConfig(
+            server_url=server_url.rstrip("/"),
+            topic=get_bws_secret_value(secret_id),
+            source="bws",
+        )
+
+    topic = get_env("BUY_TICKET_AGENT_NTFY_TOPIC") or get_env("NTFY_TOPIC")
+    if topic is None:
+        return None
+    return NotificationConfig(
+        server_url=server_url.rstrip("/"),
+        topic=topic,
+        source="env",
+    )

--- a/buy_ticket_agent/state.py
+++ b/buy_ticket_agent/state.py
@@ -1,0 +1,179 @@
+"""SQLite state store for buy-ticket agent smoke runs."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS runs (
+        id TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL,
+        trigger TEXT NOT NULL,
+        status TEXT NOT NULL,
+        draft_path TEXT,
+        log_path TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tickets (
+        id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        ticker TEXT NOT NULL,
+        status TEXT NOT NULL,
+        draft_path TEXT NOT NULL,
+        preview TEXT NOT NULL,
+        FOREIGN KEY(run_id) REFERENCES runs(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS decisions (
+        id TEXT PRIMARY KEY,
+        ticket_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        decision TEXT NOT NULL,
+        source TEXT NOT NULL,
+        FOREIGN KEY(ticket_id) REFERENCES tickets(id)
+    )
+    """,
+)
+
+
+@contextmanager
+def connect_state(db_path: Path) -> Iterator[sqlite3.Connection]:
+    """Open the SQLite state database and ensure parent directories exist."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.row_factory = sqlite3.Row
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def initialize_state(db_path: Path) -> None:
+    """Create the smoke state schema idempotently."""
+    with connect_state(db_path) as conn:
+        for statement in SCHEMA_STATEMENTS:
+            conn.execute(statement)
+
+
+def record_smoke_run(
+    db_path: Path,
+    *,
+    run_id: str,
+    ticket_id: str,
+    created_at: str,
+    ticker: str,
+    status: str,
+    draft_path: Path,
+    log_path: Path,
+    preview: str,
+) -> None:
+    """Persist run, ticket, and initial decision rows in one transaction."""
+    with connect_state(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO runs
+                (id, created_at, trigger, status, draft_path, log_path)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                created_at = excluded.created_at,
+                trigger = excluded.trigger,
+                status = excluded.status,
+                draft_path = excluded.draft_path,
+                log_path = excluded.log_path
+            """,
+            (
+                run_id,
+                created_at,
+                "smoke",
+                status,
+                str(draft_path),
+                str(log_path),
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO tickets
+                (id, run_id, created_at, ticker, status, draft_path, preview)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                run_id = excluded.run_id,
+                created_at = excluded.created_at,
+                ticker = excluded.ticker,
+                status = excluded.status,
+                draft_path = excluded.draft_path,
+                preview = excluded.preview
+            """,
+            (
+                ticket_id,
+                run_id,
+                created_at,
+                ticker,
+                status,
+                str(draft_path),
+                preview,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO decisions
+                (id, ticket_id, created_at, decision, source)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                ticket_id = excluded.ticket_id,
+                created_at = excluded.created_at,
+                decision = excluded.decision,
+                source = excluded.source
+            """,
+            (
+                f"{ticket_id}-pending",
+                ticket_id,
+                created_at,
+                "pending",
+                "smoke",
+            ),
+        )
+
+
+def record_smoke_failure(
+    db_path: Path,
+    *,
+    run_id: str,
+    created_at: str,
+    status: str,
+    log_path: Path,
+) -> None:
+    """Persist a smoke run failure before any ticket draft exists."""
+    with connect_state(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO runs
+                (id, created_at, trigger, status, draft_path, log_path)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                created_at = excluded.created_at,
+                trigger = excluded.trigger,
+                status = excluded.status,
+                draft_path = excluded.draft_path,
+                log_path = excluded.log_path
+            """,
+            (
+                run_id,
+                created_at,
+                "smoke",
+                status,
+                None,
+                str(log_path),
+            ),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
 testpaths = ["tests/python"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short --cov=src --cov-report=term-missing --cov-fail-under=80 -n auto --reruns 1 --durations=10"
+addopts = "-v --tb=short --cov=src --cov=buy_ticket_agent --cov-report=term-missing --cov-fail-under=80 -n auto --reruns 1 --durations=10"
 pythonpath = ["."]
 markers = [
     "integration: marks tests as integration tests (require real API keys)",
@@ -108,7 +108,7 @@ ignore_names = ["_*", "test_*", "setUp", "tearDown"]
 
 [tool.coverage.run]
 branch = true
-source = ["src"]
+source = ["src", "buy_ticket_agent"]
 omit = [
     "src/*/*_cli.py",
     "src/*_cli.py",

--- a/tests/python/test_buy_ticket_agent_smoke.py
+++ b/tests/python/test_buy_ticket_agent_smoke.py
@@ -1,0 +1,479 @@
+"""Tests for the buy-ticket agent smoke scaffold."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from buy_ticket_agent.config import NotificationConfig
+from buy_ticket_agent.main import main
+from buy_ticket_agent.notifier import NotificationResult, push_ticket_preview
+from buy_ticket_agent.pipeline import SmokeResult, run_layer3_smoke_cli, run_smoke
+from buy_ticket_agent.secrets import (
+    SecretAccessError,
+    get_bws_secret_value,
+    resolve_notification_config,
+)
+from buy_ticket_agent.state import connect_state, initialize_state, record_smoke_run
+
+
+def test_initialize_state_is_idempotent(tmp_path: Path) -> None:
+    """State schema can be initialized repeatedly without losing rows."""
+    db_path = tmp_path / "state.db"
+
+    initialize_state(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO runs (id, created_at, trigger, status) VALUES (?, ?, ?, ?)",
+            ("run-1", "2026-06-05T00:00:00+00:00", "smoke", "completed"),
+        )
+
+    initialize_state(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        count = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+
+    assert {"runs", "tickets", "decisions"}.issubset(tables)
+    assert count == 1
+
+
+def test_state_connections_enforce_foreign_keys(tmp_path: Path) -> None:
+    """State connections enforce declared SQLite foreign key constraints."""
+    db_path = tmp_path / "state.db"
+    initialize_state(db_path)
+
+    try:
+        with connect_state(db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO tickets
+                    (id, run_id, created_at, ticker, status, draft_path, preview)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "ticket-1",
+                    "missing-run",
+                    "2026-06-05T00:00:00+00:00",
+                    "SPY",
+                    "completed",
+                    "draft.json",
+                    "preview",
+                ),
+            )
+    except sqlite3.IntegrityError:
+        pass
+    else:
+        raise AssertionError("Expected SQLite foreign key enforcement")
+
+
+def test_record_smoke_run_is_idempotent_with_foreign_keys(tmp_path: Path) -> None:
+    """Smoke run upserts do not violate foreign keys on repeated IDs."""
+    db_path = tmp_path / "state.db"
+    initialize_state(db_path)
+
+    common = {
+        "run_id": "run-1",
+        "ticket_id": "ticket-1",
+        "created_at": "2026-06-05T00:00:00+00:00",
+        "ticker": "SPY",
+        "log_path": tmp_path / "log.json",
+    }
+    record_smoke_run(
+        db_path,
+        **common,
+        status="completed",
+        draft_path=tmp_path / "draft-1.json",
+        preview="first preview",
+    )
+    record_smoke_run(
+        db_path,
+        **common,
+        status="notification_failed",
+        draft_path=tmp_path / "draft-2.json",
+        preview="second preview",
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        counts = (
+            conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0],
+            conn.execute("SELECT COUNT(*) FROM tickets").fetchone()[0],
+            conn.execute("SELECT COUNT(*) FROM decisions").fetchone()[0],
+        )
+        status = conn.execute("SELECT status FROM tickets").fetchone()[0]
+        preview = conn.execute("SELECT preview FROM tickets").fetchone()[0]
+
+    assert counts == (1, 1, 1)
+    assert status == "notification_failed"
+    assert preview == "second preview"
+
+
+def test_bws_secret_value_parses_without_printing_secret() -> None:
+    """BWS resolver returns only the value field."""
+    completed = MagicMock()
+    completed.stdout = json.dumps({"value": "topic-value"})
+
+    with patch(
+        "buy_ticket_agent.secrets.subprocess.run", return_value=completed
+    ) as run:
+        value = get_bws_secret_value("secret-id")
+
+    assert value == "topic-value"
+    assert run.call_args.args[0] == [
+        "bws",
+        "secret",
+        "get",
+        "secret-id",
+        "--output",
+        "json",
+    ]
+
+
+def test_notification_config_prefers_bws_secret(monkeypatch) -> None:
+    """Configured BWS secret id is used before direct topic environment."""
+    monkeypatch.setenv("BUY_TICKET_AGENT_NTFY_TOPIC_SECRET_ID", "secret-id")
+    monkeypatch.setenv("NTFY_TOPIC", "env-topic")
+
+    with patch(
+        "buy_ticket_agent.secrets.get_bws_secret_value",
+        return_value="bws-topic",
+    ):
+        config = resolve_notification_config()
+
+    assert config == NotificationConfig(
+        server_url="https://ntfy.sh",
+        topic="bws-topic",
+        source="bws",
+    )
+
+
+def test_push_ticket_preview_posts_to_ntfy() -> None:
+    """Notification client posts the preview body and reports sent."""
+    config = NotificationConfig(
+        server_url="https://ntfy.example.test",
+        topic="topic/a?b=c",
+        source="bws",
+    )
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+
+    with patch(
+        "buy_ticket_agent.notifier.requests.post", return_value=response
+    ) as post:
+        result = push_ticket_preview(
+            config,
+            ticket_id="ticket-1",
+            preview="SPY shadow draft ready for review",
+        )
+
+    assert result.status == "sent"
+    assert result.source == "bws"
+    assert post.call_args.args[0] == "https://ntfy.example.test/topic%2Fa%3Fb%3Dc"
+    assert b"ticket-1" in post.call_args.kwargs["data"]
+
+
+def test_run_smoke_writes_draft_log_and_state(tmp_path: Path, monkeypatch) -> None:
+    """Smoke run writes the expected artifacts and persists state rows."""
+    monkeypatch.delenv("BUY_TICKET_AGENT_NTFY_TOPIC_SECRET_ID", raising=False)
+    monkeypatch.delenv("NTFY_TOPIC_SECRET_ID", raising=False)
+    monkeypatch.delenv("BUY_TICKET_AGENT_NTFY_TOPIC", raising=False)
+    monkeypatch.delenv("NTFY_TOPIC", raising=False)
+    monkeypatch.setenv("ITC_API_KEY", "test-key")
+
+    completed = MagicMock()
+    completed.returncode = 0
+    completed.stdout = '{"symbol":"SP500","current_risk_score":0.4}'
+    completed.stderr = "ok"
+
+    with (
+        patch(
+            "buy_ticket_agent.pipeline.subprocess.run", return_value=completed
+        ) as run,
+        patch("buy_ticket_agent.pipeline._utc_now") as now,
+    ):
+        from datetime import UTC, datetime
+
+        now.return_value = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
+        result = run_smoke(project_root=tmp_path)
+
+    draft_path = tmp_path / result.draft_path
+    log_path = tmp_path / result.log_path
+    state_db = tmp_path / result.state_db
+
+    assert result.status == "completed"
+    assert result.notification.status == "skipped"
+    assert result.notification.error is None
+    assert draft_path.exists()
+    assert log_path.exists()
+    assert state_db.exists()
+
+    draft = json.loads(draft_path.read_text())
+    log = json.loads(log_path.read_text())
+    assert draft["ticker"] == "SPY"
+    assert draft["analysis_proxy"] == "SP500"
+    assert "not investment advice" in draft["disclaimer"]
+    assert log["layer3"]["status"] == "succeeded"
+    assert log["layer3"]["command"][0] == "python"
+    assert log["layer3"]["stdout_chars"] == len(completed.stdout)
+    assert log["layer3"]["stderr_chars"] == len(completed.stderr)
+    assert "stdout" not in log["layer3"]
+    assert "stderr" not in log["layer3"]
+    assert result.draft_path == (
+        f"fin-guru-private/fin-guru/tickets/auto-drafts/{result.run_id}.json"
+    )
+    assert result.log_path.startswith("notebooks/auto-tickets/runs/smoke-20260605-")
+    assert result.state_db == "notebooks/auto-tickets/state.db"
+
+    command = run.call_args.args[0]
+    assert command[1:] == [
+        "src/analysis/itc_risk_cli.py",
+        "SP500",
+        "--universe",
+        "tradfi",
+        "--output",
+        "json",
+        "--no-price",
+    ]
+
+    with sqlite3.connect(state_db) as conn:
+        run_count = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+        ticket_count = conn.execute("SELECT COUNT(*) FROM tickets").fetchone()[0]
+        decision_count = conn.execute("SELECT COUNT(*) FROM decisions").fetchone()[0]
+
+    assert (run_count, ticket_count, decision_count) == (1, 1, 1)
+
+
+def test_run_smoke_does_not_record_success_state_if_log_write_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Successful smoke runs do not persist state until the run log exists."""
+    monkeypatch.delenv("BUY_TICKET_AGENT_NTFY_TOPIC_SECRET_ID", raising=False)
+    monkeypatch.delenv("NTFY_TOPIC_SECRET_ID", raising=False)
+    monkeypatch.delenv("BUY_TICKET_AGENT_NTFY_TOPIC", raising=False)
+    monkeypatch.delenv("NTFY_TOPIC", raising=False)
+
+    completed = MagicMock()
+    completed.returncode = 0
+    completed.stdout = '{"symbol":"SP500","current_risk_score":0.4}'
+    completed.stderr = ""
+
+    def write_json_or_fail_log(path: Path, payload: dict) -> None:
+        if path.parent.name == "runs":
+            raise OSError("log write failed")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    with (
+        patch("buy_ticket_agent.pipeline.subprocess.run", return_value=completed),
+        patch(
+            "buy_ticket_agent.pipeline._write_json", side_effect=write_json_or_fail_log
+        ),
+    ):
+        try:
+            run_smoke(project_root=tmp_path)
+        except OSError:
+            pass
+        else:
+            raise AssertionError("Expected log write failure")
+
+    state_db = tmp_path / "notebooks" / "auto-tickets" / "state.db"
+    with sqlite3.connect(state_db) as conn:
+        counts = (
+            conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0],
+            conn.execute("SELECT COUNT(*) FROM tickets").fetchone()[0],
+            conn.execute("SELECT COUNT(*) FROM decisions").fetchone()[0],
+        )
+
+    assert counts == (0, 0, 0)
+
+
+def test_layer3_smoke_cli_without_api_key_uses_capability_probe(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Layer 3 smoke remains credential-free until analysis credentials exist."""
+    monkeypatch.delenv("ITC_API_KEY", raising=False)
+    completed = MagicMock()
+    completed.returncode = 0
+    completed.stdout = "supported tickers"
+    completed.stderr = ""
+
+    with patch(
+        "buy_ticket_agent.pipeline.subprocess.run", return_value=completed
+    ) as run:
+        result = run_layer3_smoke_cli(project_root=tmp_path)
+
+    assert result.status == "succeeded"
+    assert run.call_args.args[0][1:] == [
+        "src/analysis/itc_risk_cli.py",
+        "--list-supported",
+        "tradfi",
+    ]
+
+
+def test_run_smoke_layer3_failure_records_failure_without_draft(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Layer 3 failures are logged without persisting raw CLI output."""
+    monkeypatch.delenv("BUY_TICKET_AGENT_NTFY_TOPIC_SECRET_ID", raising=False)
+    monkeypatch.delenv("NTFY_TOPIC_SECRET_ID", raising=False)
+    monkeypatch.delenv("BUY_TICKET_AGENT_NTFY_TOPIC", raising=False)
+    monkeypatch.delenv("NTFY_TOPIC", raising=False)
+
+    completed = MagicMock()
+    completed.returncode = 2
+    completed.stdout = "SECRET_TOKEN=secret-value"
+    completed.stderr = "private stderr output"
+
+    with (
+        patch("buy_ticket_agent.pipeline.subprocess.run", return_value=completed),
+        patch("buy_ticket_agent.pipeline._utc_now") as now,
+    ):
+        from datetime import UTC, datetime
+
+        now.return_value = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
+        result = run_smoke(project_root=tmp_path)
+
+    log_path = tmp_path / result.log_path
+    state_db = tmp_path / result.state_db
+    log_text = log_path.read_text()
+    log = json.loads(log_text)
+
+    assert result.status == "layer3_failed"
+    assert result.ticket_id is None
+    assert result.draft_path is None
+    assert result.notification is None
+    assert not (
+        tmp_path / "fin-guru-private" / "fin-guru" / "tickets" / "auto-drafts"
+    ).exists()
+    assert log["layer3"]["returncode"] == 2
+    assert log["layer3"]["stdout_chars"] == len(completed.stdout)
+    assert log["layer3"]["stderr_chars"] == len(completed.stderr)
+    assert "SECRET_TOKEN" not in log_text
+    assert "secret-value" not in log_text
+    assert "private stderr output" not in log_text
+
+    with sqlite3.connect(state_db) as conn:
+        run_count = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+        ticket_count = conn.execute("SELECT COUNT(*) FROM tickets").fetchone()[0]
+        decision_count = conn.execute("SELECT COUNT(*) FROM decisions").fetchone()[0]
+
+    assert (run_count, ticket_count, decision_count) == (1, 0, 0)
+
+
+def test_run_smoke_does_not_record_failure_state_if_log_write_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Failed smoke runs do not persist state until the failure log exists."""
+    monkeypatch.delenv("BUY_TICKET_AGENT_NTFY_TOPIC_SECRET_ID", raising=False)
+    monkeypatch.delenv("NTFY_TOPIC_SECRET_ID", raising=False)
+    monkeypatch.delenv("BUY_TICKET_AGENT_NTFY_TOPIC", raising=False)
+    monkeypatch.delenv("NTFY_TOPIC", raising=False)
+
+    completed = MagicMock()
+    completed.returncode = 2
+    completed.stdout = "failed"
+    completed.stderr = ""
+
+    with (
+        patch("buy_ticket_agent.pipeline.subprocess.run", return_value=completed),
+        patch(
+            "buy_ticket_agent.pipeline._write_json",
+            side_effect=OSError("log write failed"),
+        ),
+    ):
+        try:
+            run_smoke(project_root=tmp_path)
+        except OSError:
+            pass
+        else:
+            raise AssertionError("Expected log write failure")
+
+    state_db = tmp_path / "notebooks" / "auto-tickets" / "state.db"
+    with sqlite3.connect(state_db) as conn:
+        counts = (
+            conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0],
+            conn.execute("SELECT COUNT(*) FROM tickets").fetchone()[0],
+            conn.execute("SELECT COUNT(*) FROM decisions").fetchone()[0],
+        )
+
+    assert counts == (0, 0, 0)
+
+
+def test_layer3_smoke_cli_timeout_returns_structured_failure(tmp_path: Path) -> None:
+    """Layer 3 subprocess timeouts return a structured failure envelope."""
+    with patch(
+        "buy_ticket_agent.pipeline.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(
+            cmd=["python"],
+            timeout=60,
+            output="partial",
+            stderr="timed out",
+        ),
+    ):
+        result = run_layer3_smoke_cli(project_root=tmp_path)
+
+    assert result.status == "failed"
+    assert result.returncode == -1
+    assert result.error == "TimeoutExpired"
+    assert result.stdout_chars == len("partial")
+    assert result.stderr_chars == len("timed out")
+
+
+def test_run_smoke_secret_failure_leaves_no_partial_artifacts(tmp_path: Path) -> None:
+    """BWS failures stop before filesystem or state artifacts are created."""
+    with patch(
+        "buy_ticket_agent.pipeline.resolve_notification_config",
+        side_effect=SecretAccessError("bws unavailable"),
+    ):
+        try:
+            run_smoke(project_root=tmp_path)
+        except SecretAccessError:
+            pass
+        else:
+            raise AssertionError("Expected SecretAccessError")
+
+    assert not (
+        tmp_path / "fin-guru-private" / "fin-guru" / "tickets" / "auto-drafts"
+    ).exists()
+    assert not (tmp_path / "notebooks" / "auto-tickets" / "state.db").exists()
+    assert not (tmp_path / "notebooks" / "auto-tickets" / "runs").exists()
+
+
+def test_main_smoke_exits_zero(tmp_path: Path) -> None:
+    """CLI smoke command prints a result envelope and exits successfully."""
+    result = SmokeResult(
+        run_id="run-1",
+        ticket_id="ticket-1",
+        status="completed",
+        draft_path=str(tmp_path / "draft.json"),
+        log_path=str(tmp_path / "log.json"),
+        state_db=str(tmp_path / "state.db"),
+        notification=NotificationResult(status="sent", source="bws"),
+    )
+
+    with patch("buy_ticket_agent.main.run_smoke_for_cli", return_value=result):
+        assert main(["--smoke"]) == 0
+
+
+def test_main_smoke_returns_nonzero_for_failed_result(tmp_path: Path) -> None:
+    """CLI smoke command exits nonzero when the smoke result failed."""
+    result = SmokeResult(
+        run_id="run-1",
+        ticket_id=None,
+        status="layer3_failed",
+        draft_path=None,
+        log_path=str(tmp_path / "log.json"),
+        state_db=str(tmp_path / "state.db"),
+        notification=None,
+    )
+
+    with patch("buy_ticket_agent.main.run_smoke_for_cli", return_value=result):
+        assert main(["--smoke"]) == 1


### PR DESCRIPTION
## Summary
- Adds a configurable AOJ-458 smoke command that writes local draft, run, and state artifacts.
- Wires optional notification delivery through environment or secret-managed configuration.
- Records Layer 3 CLI status without persisting raw subprocess output.

## Test Plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/`
- [x] `uv run mypy buy_ticket_agent`
- [x] `uv run pytest tests/python/test_buy_ticket_agent_smoke.py -q --no-cov`
- [x] `uv run pytest -q -m "not integration"`
- [x] `uv run python -m buy_ticket_agent.main --smoke`
- [x] CodeRabbit CLI review: 0 findings

## Review Checklist
- [x] No secrets or PII committed
- [x] Public metadata sanitized for AOJ-458
- [x] No public GitHub issue mirrored

## Linked Issues
- No public GitHub issue; AOJ-458 only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a buy‑ticket smoke CLI command that produces shadow drafts, writes structured run logs, optionally sends ntfy preview notifications, resolves notification settings via Bitwarden or env, and persists run state to a local SQLite store.
* **Documentation**
  * Added README documenting the smoke workflow and invocation.
* **Tests**
  * Added comprehensive smoke tests covering CLI flow, secrets resolution, notifications, state persistence, and failure/timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->