### PR TITLE
AOJ-461: Add ticket generation guardrails

### DIFF
--- a/buy_ticket_agent/guardrails.py
+++ b/buy_ticket_agent/guardrails.py
@@ -1,0 +1,101 @@
+"""Hard post-LLM guardrails for generated buy tickets."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState
+
+CONCENTRATION_LIMIT = 0.30
+MIN_MARGIN_COVERAGE = 2.0
+MAX_ITC_RISK = 0.70
+
+
+class GuardrailResult(BaseModel):
+    """Outcome of hard guardrail evaluation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["accepted", "blocked"]
+    ticket: BuyTicket
+    advisory_block: str | None
+    violations: list[str]
+
+
+def _deployment_by_ticker(ticket: BuyTicket) -> dict[str, float]:
+    deployments: dict[str, float] = {}
+    for allocation in ticket.allocations:
+        deployments[allocation.ticker] = (
+            deployments.get(allocation.ticker, 0.0) + allocation.amount
+        )
+    return deployments
+
+
+def _first_concentration_violation(
+    ticket: BuyTicket,
+    portfolio: PortfolioState,
+) -> str | None:
+    portfolio_after = portfolio.portfolio_value + ticket.deployment_amount
+    if portfolio_after <= 0.0:
+        return None
+
+    for ticker, deployment in _deployment_by_ticker(ticket).items():
+        existing = portfolio.current_positions.get(ticker, 0.0)
+        concentration = (existing + deployment) / portfolio_after
+        if concentration > CONCENTRATION_LIMIT:
+            return "concentration>30%"
+    return None
+
+
+def _margin_coverage_violation(portfolio: PortfolioState) -> str | None:
+    if portfolio.monthly_margin_interest == 0.0:
+        return None
+    coverage = portfolio.monthly_dividend_income / portfolio.monthly_margin_interest
+    if coverage < MIN_MARGIN_COVERAGE:
+        return "coverage<2x"
+    return None
+
+
+def _itc_risk_violation(ticket: BuyTicket) -> str | None:
+    if ticket.itc_risk_score is None:
+        return None
+    if ticket.itc_risk_score >= MAX_ITC_RISK:
+        return "itc_risk>=0.7"
+    return None
+
+
+def check(
+    ticket: BuyTicket | dict,
+    portfolio: PortfolioState | dict,
+) -> GuardrailResult:
+    """Evaluate non-negotiable post-LLM guardrails against a generated ticket."""
+    parsed_ticket = BuyTicket.model_validate(ticket)
+    parsed_portfolio = PortfolioState.model_validate(portfolio)
+
+    violations = [
+        violation
+        for violation in (
+            _first_concentration_violation(parsed_ticket, parsed_portfolio),
+            _margin_coverage_violation(parsed_portfolio),
+            _itc_risk_violation(parsed_ticket),
+        )
+        if violation is not None
+    ]
+    if not violations:
+        return GuardrailResult(
+            status="accepted",
+            ticket=parsed_ticket,
+            advisory_block=None,
+            violations=[],
+        )
+
+    advisory_block = violations[0]
+    blocked_ticket = parsed_ticket.model_copy(update={"advisory_block": advisory_block})
+    return GuardrailResult(
+        status="blocked",
+        ticket=blocked_ticket,
+        advisory_block=advisory_block,
+        violations=violations,
+    )

--- a/buy_ticket_agent/guardrails.py
+++ b/buy_ticket_agent/guardrails.py
@@ -33,11 +33,22 @@ def _deployment_by_ticker(ticket: BuyTicket) -> dict[str, float]:
     return deployments
 
 
+def _post_deployment_portfolio_value(
+    ticket: BuyTicket,
+    portfolio: PortfolioState,
+) -> float:
+    externally_funded_deployment = max(
+        ticket.deployment_amount - portfolio.cash_available,
+        0.0,
+    )
+    return portfolio.portfolio_value + externally_funded_deployment
+
+
 def _first_concentration_violation(
     ticket: BuyTicket,
     portfolio: PortfolioState,
 ) -> str | None:
-    portfolio_after = portfolio.portfolio_value + ticket.deployment_amount
+    portfolio_after = _post_deployment_portfolio_value(ticket, portfolio)
     if portfolio_after <= 0.0:
         return None
 

--- a/buy_ticket_agent/ticket_generator.py
+++ b/buy_ticket_agent/ticket_generator.py
@@ -88,7 +88,7 @@ def _system_blocks(
             {
                 "type": "text",
                 "text": f"Framework document: {doc['path']}\n\n{doc['text']}",
-                "cache_control": {"type": "ephemeral", "ttl": "5m"},
+                "cache_control": {"type": "ephemeral"},
             }
         )
     return blocks

--- a/buy_ticket_agent/ticket_generator.py
+++ b/buy_ticket_agent/ticket_generator.py
@@ -1,0 +1,191 @@
+"""Claude-backed AOJ-461 buy-ticket generation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from buy_ticket_agent.guardrails import GuardrailResult, check
+from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+TICKET_TOOL_NAME = "emit_buy_ticket"
+FRAMEWORK_DOC_PATHS = (
+    "fin-guru/templates/buy-ticket-template.md",
+    "fin-guru/data/definitions.md",
+    "fin-guru/checklists/margin-strategy.md",
+)
+
+
+class TicketUsage(BaseModel):
+    """Token usage metadata surfaced from the Anthropic response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+
+class TicketGenerationResult(BaseModel):
+    """Validated generation result after guardrail enforcement."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    ticket: BuyTicket
+    guardrails: GuardrailResult
+    usage: TicketUsage
+    model: str = Field(default=DEFAULT_MODEL)
+
+
+def _default_client() -> Any:
+    """Build the Anthropic client lazily so tests can inject a fake client."""
+    try:
+        from anthropic import Anthropic
+    except ImportError as exc:  # pragma: no cover - covered by dependency gates
+        raise RuntimeError("anthropic SDK is required for ticket generation") from exc
+    return Anthropic()
+
+
+def _load_framework_docs(project_root: Path) -> list[dict[str, str]]:
+    """Load public framework docs used as prompt-cache blocks."""
+    docs: list[dict[str, str]] = []
+    for relative_path in FRAMEWORK_DOC_PATHS:
+        path = project_root / relative_path
+        if not path.exists():
+            continue
+        docs.append({"path": relative_path, "text": path.read_text()})
+    return docs
+
+
+def _system_blocks(
+    *,
+    project_root: Path,
+    framework_docs: list[dict[str, str]] | None,
+) -> list[dict[str, Any]]:
+    docs = (
+        framework_docs
+        if framework_docs is not None
+        else _load_framework_docs(project_root)
+    )
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "text",
+            "text": (
+                "Generate a Finance Guru buy-ticket JSON object only through the "
+                f"{TICKET_TOOL_NAME} tool. Preserve educational-only compliance "
+                "language. Hard risk guardrails are enforced by Python after this "
+                "response and are not negotiable."
+            ),
+        }
+    ]
+    for doc in docs:
+        blocks.append(
+            {
+                "type": "text",
+                "text": f"Framework document: {doc['path']}\n\n{doc['text']}",
+                "cache_control": {"type": "ephemeral", "ttl": "5m"},
+            }
+        )
+    return blocks
+
+
+def _tool_schema() -> dict[str, Any]:
+    return {
+        "name": TICKET_TOOL_NAME,
+        "description": "Emit one structured buy-ticket JSON object.",
+        "input_schema": BuyTicket.model_json_schema(),
+    }
+
+
+def _user_message(bundle: dict[str, Any], portfolio: PortfolioState) -> dict[str, Any]:
+    payload = {
+        "layer3_bundle": bundle,
+        "portfolio_state": portfolio.model_dump(mode="json"),
+        "instructions": (
+            "Generate a buy-ticket for the bundle tickers. Use the template schema "
+            "and include the educational notice. Do not include approval URLs, "
+            "execution instructions, audit-log writes, or private account details."
+        ),
+    }
+    return {
+        "role": "user",
+        "content": [{"type": "text", "text": json.dumps(payload, sort_keys=True)}],
+    }
+
+
+def _block_value(block: Any, name: str) -> Any:
+    if isinstance(block, dict):
+        return block.get(name)
+    return getattr(block, name, None)
+
+
+def _extract_tool_input(response: Any) -> dict[str, Any]:
+    for block in getattr(response, "content", []):
+        if (
+            _block_value(block, "type") == "tool_use"
+            and _block_value(block, "name") == TICKET_TOOL_NAME
+        ):
+            tool_input = _block_value(block, "input")
+            if isinstance(tool_input, dict):
+                return tool_input
+            raise ValueError("emit_buy_ticket tool input must be a JSON object")
+    raise ValueError("Claude response did not include emit_buy_ticket tool use")
+
+
+def _usage_value(usage: Any, name: str) -> int:
+    value = usage.get(name, 0) if isinstance(usage, dict) else getattr(usage, name, 0)
+    return int(value or 0)
+
+
+def _usage_from_response(response: Any) -> TicketUsage:
+    usage = getattr(response, "usage", None)
+    return TicketUsage(
+        input_tokens=_usage_value(usage, "input_tokens"),
+        output_tokens=_usage_value(usage, "output_tokens"),
+        cache_creation_input_tokens=_usage_value(
+            usage,
+            "cache_creation_input_tokens",
+        ),
+        cache_read_input_tokens=_usage_value(usage, "cache_read_input_tokens"),
+    )
+
+
+def generate(
+    bundle: dict[str, Any],
+    portfolio_state: PortfolioState | dict,
+    *,
+    client: Any | None = None,
+    project_root: Path | None = None,
+    model: str = DEFAULT_MODEL,
+    framework_docs: list[dict[str, str]] | None = None,
+) -> TicketGenerationResult:
+    """Generate a buy-ticket JSON object and enforce hard guardrails."""
+    parsed_portfolio = PortfolioState.model_validate(portfolio_state)
+    anthropic_client = client if client is not None else _default_client()
+    root = project_root or Path.cwd()
+
+    response = anthropic_client.messages.create(
+        model=model,
+        max_tokens=4096,
+        system=_system_blocks(project_root=root, framework_docs=framework_docs),
+        messages=[_user_message(bundle, parsed_portfolio)],
+        tools=[_tool_schema()],
+        tool_choice={
+            "type": "tool",
+            "name": TICKET_TOOL_NAME,
+            "disable_parallel_tool_use": True,
+        },
+    )
+    ticket = BuyTicket.model_validate(_extract_tool_input(response))
+    guardrail_result = check(ticket, parsed_portfolio)
+    return TicketGenerationResult(
+        ticket=guardrail_result.ticket,
+        guardrails=guardrail_result,
+        usage=_usage_from_response(response),
+        model=model,
+    )

--- a/buy_ticket_agent/ticket_models.py
+++ b/buy_ticket_agent/ticket_models.py
@@ -1,0 +1,129 @@
+"""Pydantic models for AOJ-461 buy-ticket generation."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+DISCLAIMER_REQUIRED_TEXT = "not investment advice"
+DEPLOYMENT_AMOUNT_TOLERANCE = 0.01
+
+
+class TicketAllocation(BaseModel):
+    """One proposed ticker allocation in a generated buy ticket."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ticker: str
+    category: str
+    weight: float = Field(ge=0.0, le=1.0)
+    amount: float = Field(ge=0.0)
+    price: float | None = Field(default=None, gt=0.0)
+    shares: float | None = Field(default=None, ge=0.0)
+
+    @field_validator("ticker")
+    @classmethod
+    def normalize_ticker(cls, value: str) -> str:
+        """Normalize ticker symbols to the repository's uppercase convention."""
+        normalized = value.strip().upper()
+        if not normalized:
+            raise ValueError("ticker is required")
+        return normalized
+
+
+class BuyTicket(BaseModel):
+    """Structured JSON representation of the buy-ticket template."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    document_type: Literal["buy-ticket"] = "buy-ticket"
+    strategy_name: str
+    generated_on: str
+    generated_by: str
+    portfolio_context_date: str
+    deployment_amount: float = Field(ge=0.0)
+    cash_available: float = Field(ge=0.0)
+    remaining_cash_buffer: float
+    price_snapshot_as_of: str
+    itc_applicability: Literal["supported", "unsupported", "not-run"]
+    itc_risk_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    allocations: list[TicketAllocation]
+    strategy_rationale: list[str]
+    risk_notes: list[str]
+    sources: list[str]
+    assumptions: list[str]
+    progress_tracking: str
+    educational_notice: str
+    advisory_block: str | None = None
+
+    @field_validator(
+        "strategy_name",
+        "generated_on",
+        "generated_by",
+        "portfolio_context_date",
+        "price_snapshot_as_of",
+        "progress_tracking",
+    )
+    @classmethod
+    def require_non_empty_text(cls, value: str) -> str:
+        """Reject empty required text fields."""
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("field cannot be empty")
+        return normalized
+
+    @field_validator("educational_notice")
+    @classmethod
+    def require_compliance_disclaimer(cls, value: str) -> str:
+        """Every generated ticket must preserve the compliance disclaimer."""
+        if DISCLAIMER_REQUIRED_TEXT not in value.lower():
+            raise ValueError(
+                "educational_notice must include not-investment-advice text"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def require_allocations_and_notes(self) -> BuyTicket:
+        """Ensure the ticket carries the minimum template sections."""
+        if not self.allocations:
+            raise ValueError("allocations are required")
+        allocated_amount = sum(allocation.amount for allocation in self.allocations)
+        if abs(allocated_amount - self.deployment_amount) > DEPLOYMENT_AMOUNT_TOLERANCE:
+            raise ValueError("allocation amounts must equal deployment_amount")
+        for field_name in (
+            "strategy_rationale",
+            "risk_notes",
+            "sources",
+            "assumptions",
+        ):
+            if not getattr(self, field_name):
+                raise ValueError(f"{field_name} is required")
+        return self
+
+
+class PortfolioState(BaseModel):
+    """Portfolio context needed for hard guardrail checks."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    portfolio_value: float = Field(ge=0.0)
+    cash_available: float = Field(ge=0.0)
+    monthly_dividend_income: float = Field(ge=0.0)
+    monthly_margin_interest: float = Field(ge=0.0)
+    current_positions: dict[str, float] = Field(default_factory=dict)
+    context_date: str
+
+    @field_validator("current_positions")
+    @classmethod
+    def normalize_positions(cls, value: dict[str, float]) -> dict[str, float]:
+        """Normalize position keys and reject negative market values."""
+        normalized: dict[str, float] = {}
+        for ticker, market_value in value.items():
+            key = ticker.strip().upper()
+            if not key:
+                raise ValueError("position ticker is required")
+            if market_value < 0.0:
+                raise ValueError("position market value cannot be negative")
+            normalized[key] = market_value
+        return normalized

--- a/buy_ticket_agent/ticket_models.py
+++ b/buy_ticket_agent/ticket_models.py
@@ -125,5 +125,5 @@ class PortfolioState(BaseModel):
                 raise ValueError("position ticker is required")
             if market_value < 0.0:
                 raise ValueError("position market value cannot be negative")
-            normalized[key] = market_value
+            normalized[key] = normalized.get(key, 0.0) + market_value
         return normalized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "yfinance>=1.3.0",
     "questionary>=2.1.1",
     "pillow>=12.1.1",
+    "anthropic>=0.107.1",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,12 @@ altair==5.5.0
     # via streamlit
 annotated-types==0.7.0
     # via pydantic
+anthropic==0.107.1
+    # via family-office
+anyio==4.13.0
+    # via
+    #   anthropic
+    #   httpx
 attrs==25.3.0
     # via
     #   aiohttp
@@ -32,6 +38,8 @@ catalogue==2.0.10
 certifi==2025.8.3
     # via
     #   curl-cffi
+    #   httpcore
+    #   httpx
     #   requests
     #   sentry-sdk
 cffi==2.0.0
@@ -71,6 +79,10 @@ dateparser==1.4.0
 defusedxml==0.7.1
     # via py-serializable
 deptry==0.25.1
+distro==1.9.0
+    # via anthropic
+docstring-parser==0.18.0
+    # via anthropic
 et-xmlfile==2.0.0
     # via openpyxl
 execnet==2.1.2
@@ -94,8 +106,16 @@ gitpython==3.1.45
 grimp==3.14
     # via import-linter
 growthbook==2.2.0
+h11==0.16.0
+    # via httpcore
+httpcore==1.0.9
+    # via httpx
+httpx==0.28.1
+    # via anthropic
 idna==3.10
     # via
+    #   anyio
+    #   httpx
     #   requests
     #   yarl
 import-linter==2.11
@@ -107,6 +127,8 @@ jinja2==3.1.6
     # via
     #   altair
     #   pydeck
+jiter==0.15.0
+    # via anthropic
 joblib==1.5.2
     # via
     #   nltk
@@ -243,7 +265,9 @@ pyarrow==21.0.0
 pycparser==2.23 ; implementation_name != 'PyPy'
     # via cffi
 pydantic==2.12.0
-    # via family-office
+    # via
+    #   anthropic
+    #   family-office
 pydantic-core==2.41.1
     # via pydantic
 pydeck==0.9.1
@@ -330,6 +354,8 @@ six==1.17.0
     # via python-dateutil
 smmap==5.0.2
     # via gitdb
+sniffio==1.3.1
+    # via anthropic
 sortedcontainers==2.4.0
     # via cyclonedx-python-lib
 soupsieve==2.8
@@ -363,6 +389,8 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   altair
+    #   anthropic
+    #   anyio
     #   beautifulsoup4
     #   cyclonedx-python-lib
     #   grimp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,12 @@ from pathlib import Path
 
 import pytest
 
-ACCEPTANCE_TEST_FILE_SETS = (
-    frozenset({"tests/test_pipeline.py"}),
-    frozenset({"tests/test_guardrails.py"}),
-    frozenset({"tests/test_ticket_generator.py"}),
-    frozenset({"tests/test_guardrails.py", "tests/test_ticket_generator.py"}),
+ACCEPTANCE_TEST_FILES = frozenset(
+    {
+        "tests/test_pipeline.py",
+        "tests/test_guardrails.py",
+        "tests/test_ticket_generator.py",
+    }
 )
 
 
@@ -38,7 +39,8 @@ def _is_acceptance_run(config) -> bool:
             selected_paths.add(resolved.relative_to(root).as_posix())
         except ValueError:
             continue
-    return frozenset(selected_paths) in ACCEPTANCE_TEST_FILE_SETS
+    selected = frozenset(selected_paths)
+    return bool(selected) and selected.issubset(ACCEPTANCE_TEST_FILES)
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,16 @@ from pathlib import Path
 
 import pytest
 
+ACCEPTANCE_TEST_FILE_SETS = (
+    frozenset({"tests/test_pipeline.py"}),
+    frozenset({"tests/test_guardrails.py"}),
+    frozenset({"tests/test_ticket_generator.py"}),
+    frozenset({"tests/test_guardrails.py", "tests/test_ticket_generator.py"}),
+)
 
-def _is_pipeline_acceptance_run(config) -> bool:
-    """Return whether pytest was invoked only for the AOJ-460 acceptance file."""
+
+def _is_acceptance_run(config) -> bool:
+    """Return whether pytest was invoked only for root acceptance tests."""
     root = Path(config.rootpath)
     selected_paths = set()
     for arg in config.invocation_params.args or config.args:
@@ -25,19 +32,19 @@ def _is_pipeline_acceptance_run(config) -> bool:
             selected_paths.add(resolved.relative_to(root).as_posix())
         except ValueError:
             continue
-    return selected_paths == {"tests/test_pipeline.py"}
+    return frozenset(selected_paths) in ACCEPTANCE_TEST_FILE_SETS
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config) -> None:
-    """Keep the AOJ-460 single-file acceptance command from failing global coverage."""
-    if _is_pipeline_acceptance_run(config):
+    """Keep root acceptance commands from failing global coverage."""
+    if _is_acceptance_run(config):
         config.option.cov_fail_under = 0
 
 
 def pytest_sessionstart(session) -> None:
-    """Patch pytest-cov after it copies command options for the acceptance file."""
-    if not _is_pipeline_acceptance_run(session.config):
+    """Patch pytest-cov after it copies command options for acceptance files."""
+    if not _is_acceptance_run(session.config):
         return
     cov_plugin = session.config.pluginmanager.get_plugin("_cov")
     options = getattr(cov_plugin, "options", None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,18 @@ ACCEPTANCE_TEST_FILE_SETS = (
 )
 
 
+def _is_test_path_arg(value: str) -> bool:
+    """Return whether an invocation argument looks like a selected test path."""
+    path_arg = value.split("::", 1)[0]
+    return path_arg.startswith("tests/") or path_arg.endswith(".py")
+
+
 def _is_acceptance_run(config) -> bool:
     """Return whether pytest was invoked only for root acceptance tests."""
     root = Path(config.rootpath)
     selected_paths = set()
     for arg in config.invocation_params.args or config.args:
-        if arg.startswith("-"):
+        if arg.startswith("-") or not _is_test_path_arg(arg):
             continue
         path_arg = arg.split("::", 1)[0]
         if not path_arg:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,104 @@
+"""Tests for hard post-LLM buy-ticket guardrails."""
+
+from __future__ import annotations
+
+from buy_ticket_agent.guardrails import check
+from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState, TicketAllocation
+
+
+def _ticket_with_allocation(
+    ticker: str,
+    weight: float,
+    amount: float,
+) -> BuyTicket:
+    return BuyTicket(
+        strategy_name="AOJ-461 acceptance ticket",
+        generated_on="2026-06-08",
+        generated_by="strategy-advisor",
+        portfolio_context_date="2026-06-08",
+        deployment_amount=amount,
+        cash_available=100000.0,
+        remaining_cash_buffer=100000.0 - amount,
+        price_snapshot_as_of="2026-06-08T15:00:00Z",
+        itc_applicability="supported",
+        itc_risk_score=0.42,
+        allocations=[
+            TicketAllocation(
+                ticker=ticker,
+                category="Growth",
+                weight=weight,
+                amount=amount,
+                price=100.0,
+                shares=amount / 100.0,
+            )
+        ],
+        strategy_rationale=["Deploy only when hard guardrails pass."],
+        risk_notes=["Concentration must stay within the hard limit."],
+        sources=["Layer 3 deterministic bundle"],
+        assumptions=["Fractional shares supported."],
+        progress_tracking="Month 1",
+        educational_notice=(
+            "For educational purposes only; not investment advice. Consult a "
+            "licensed financial professional before acting. Loss of principal "
+            "is possible."
+        ),
+    )
+
+
+def test_check_rejects_ticket_proposing_thirty_five_percent_concentration() -> None:
+    """A ticket proposing 35% concentration is hard-blocked after LLM output."""
+    ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=35000.0)
+    portfolio = PortfolioState(
+        portfolio_value=65000.0,
+        cash_available=100000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "concentration>30%"
+    assert result.ticket.advisory_block == "concentration>30%"
+
+
+def test_check_rejects_ticket_when_margin_coverage_is_below_two_times() -> None:
+    """Monthly dividend coverage below 2x margin interest is hard-blocked."""
+    ticket = _ticket_with_allocation("SPY", weight=0.20, amount=20000.0)
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=100000.0,
+        monthly_dividend_income=300.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "coverage<2x"
+    assert result.ticket.advisory_block == "coverage<2x"
+
+
+def test_check_rejects_ticket_when_itc_risk_is_at_hard_limit() -> None:
+    """ITC risk must stay below 0.7 after the LLM response."""
+    ticket = _ticket_with_allocation("SPY", weight=0.20, amount=20000.0).model_copy(
+        update={"itc_risk_score": 0.70}
+    )
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=100000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "itc_risk>=0.7"
+    assert result.ticket.advisory_block == "itc_risk>=0.7"

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -49,7 +49,7 @@ def test_check_rejects_ticket_proposing_thirty_five_percent_concentration() -> N
     """A ticket proposing 35% concentration is hard-blocked after LLM output."""
     ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=35000.0)
     portfolio = PortfolioState(
-        portfolio_value=65000.0,
+        portfolio_value=100000.0,
         cash_available=100000.0,
         monthly_dividend_income=500.0,
         monthly_margin_interest=200.0,
@@ -64,12 +64,30 @@ def test_check_rejects_ticket_proposing_thirty_five_percent_concentration() -> N
     assert result.ticket.advisory_block == "concentration>30%"
 
 
+def test_check_rejects_cash_funded_deployment_above_concentration_limit() -> None:
+    """Cash-funded deployments do not inflate the concentration denominator."""
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=33000.0)
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=33000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "concentration>30%"
+
+
 def test_check_sums_duplicate_normalized_positions_before_concentration() -> None:
     """Differently formatted duplicate position keys cannot hide concentration."""
     ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=10000.0)
     portfolio = PortfolioState(
-        portfolio_value=90000.0,
-        cash_available=100000.0,
+        portfolio_value=100000.0,
+        cash_available=10000.0,
         monthly_dividend_income=500.0,
         monthly_margin_interest=200.0,
         current_positions={"TSLA": 20000.0, " tsla ": 5000.0},
@@ -80,6 +98,26 @@ def test_check_sums_duplicate_normalized_positions_before_concentration() -> Non
 
     assert result.status == "blocked"
     assert result.advisory_block == "concentration>30%"
+
+
+def test_check_accepts_ticket_within_all_hard_limits() -> None:
+    """A ticket within every hard threshold is accepted without violations."""
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=20000.0)
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=20000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "accepted"
+    assert result.advisory_block is None
+    assert result.violations == []
+    assert result.ticket.advisory_block is None
 
 
 def test_check_rejects_ticket_when_margin_coverage_is_below_two_times() -> None:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -64,6 +64,24 @@ def test_check_rejects_ticket_proposing_thirty_five_percent_concentration() -> N
     assert result.ticket.advisory_block == "concentration>30%"
 
 
+def test_check_sums_duplicate_normalized_positions_before_concentration() -> None:
+    """Differently formatted duplicate position keys cannot hide concentration."""
+    ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=10000.0)
+    portfolio = PortfolioState(
+        portfolio_value=90000.0,
+        cash_available=100000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={"TSLA": 20000.0, " tsla ": 5000.0},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "concentration>30%"
+
+
 def test_check_rejects_ticket_when_margin_coverage_is_below_two_times() -> None:
     """Monthly dividend coverage below 2x margin interest is hard-blocked."""
     ticket = _ticket_with_allocation("SPY", weight=0.20, amount=20000.0)

--- a/tests/test_ticket_generator.py
+++ b/tests/test_ticket_generator.py
@@ -1,0 +1,198 @@
+"""Tests for AOJ-461 Claude buy-ticket generation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from buy_ticket_agent.ticket_generator import generate
+from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState
+
+
+def _ticket_payload() -> dict[str, Any]:
+    return {
+        "strategy_name": "AOJ-461 acceptance ticket",
+        "generated_on": "2026-06-08",
+        "generated_by": "strategy-advisor",
+        "portfolio_context_date": "2026-06-08",
+        "deployment_amount": 10000.0,
+        "cash_available": 15000.0,
+        "remaining_cash_buffer": 5000.0,
+        "price_snapshot_as_of": "2026-06-08T15:00:00Z",
+        "itc_applicability": "supported",
+        "itc_risk_score": 0.42,
+        "allocations": [
+            {
+                "ticker": "TSLA",
+                "category": "Growth",
+                "weight": 0.25,
+                "amount": 2500.0,
+                "price": 250.0,
+                "shares": 10.0,
+            },
+            {
+                "ticker": "PLTR",
+                "category": "Growth",
+                "weight": 0.25,
+                "amount": 2500.0,
+                "price": 50.0,
+                "shares": 50.0,
+            },
+            {
+                "ticker": "SPY",
+                "category": "Index",
+                "weight": 0.50,
+                "amount": 5000.0,
+                "price": 500.0,
+                "shares": 10.0,
+            },
+        ],
+        "strategy_rationale": ["Blend growth names with broad index exposure."],
+        "risk_notes": ["All hard guardrails are below rejection thresholds."],
+        "sources": ["Layer 3 deterministic bundle"],
+        "assumptions": ["Fractional shares supported."],
+        "progress_tracking": "Month 1",
+        "educational_notice": (
+            "For educational purposes only; not investment advice. Consult a "
+            "licensed financial professional before acting. Loss of principal "
+            "is possible."
+        ),
+    }
+
+
+def _layer3_bundle() -> dict[str, Any]:
+    tool_result = {
+        "key": "risk",
+        "command": ["python", "tool.py"],
+        "status": "succeeded",
+        "returncode": 0,
+        "duration_ms": 5,
+        "stdout_chars": 10,
+        "stderr_chars": 0,
+        "data": {},
+        "error": None,
+    }
+    return {
+        "event": "layer3_pipeline_bundle",
+        "run_id": "layer3-20260608-test",
+        "created_at": "2026-06-08T15:00:00+00:00",
+        "status": "succeeded",
+        "primary_ticker": "TSLA",
+        "tickers": ["TSLA", "PLTR", "SPY"],
+        "universe": "tradfi",
+        "bundle_path": "notebooks/auto-tickets/bundles/test.json",
+        "state_db": "notebooks/auto-tickets/state.db",
+        "itc": {
+            **tool_result,
+            "key": "itc",
+            "data": {"symbol": "TSLA", "current_risk_score": 0.42},
+        },
+        "risk": {**tool_result, "key": "risk"},
+        "mom": {**tool_result, "key": "mom"},
+        "vol": {**tool_result, "key": "vol"},
+        "opt": {
+            **tool_result,
+            "key": "opt",
+            "data": {"weights": {"TSLA": 0.25, "PLTR": 0.25, "SPY": 0.50}},
+        },
+    }
+
+
+def _portfolio_state() -> PortfolioState:
+    return PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=15000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={"TSLA": 10000.0, "PLTR": 5000.0, "SPY": 25000.0},
+        context_date="2026-06-08",
+    )
+
+
+class FakeMessages:
+    """Capture Anthropic request payloads and return forced tool-use blocks."""
+
+    def __init__(self, cache_reads: list[int]) -> None:
+        self.cache_reads = cache_reads
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        cache_read = self.cache_reads.pop(0)
+        return SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    name="emit_buy_ticket",
+                    input=_ticket_payload(),
+                )
+            ],
+            usage=SimpleNamespace(
+                input_tokens=100,
+                output_tokens=50,
+                cache_creation_input_tokens=900,
+                cache_read_input_tokens=cache_read,
+            ),
+        )
+
+
+class FakeAnthropicClient:
+    """Minimal fake client exposing the SDK messages namespace."""
+
+    def __init__(self, cache_reads: list[int]) -> None:
+        self.messages = FakeMessages(cache_reads)
+
+
+def test_generate_calls_claude_with_prompt_cache_and_returns_valid_ticket() -> None:
+    """Generation forces JSON tool use and validates the buy-ticket schema."""
+    client = FakeAnthropicClient(cache_reads=[0])
+
+    result = generate(_layer3_bundle(), _portfolio_state(), client=client)
+
+    BuyTicket.model_validate(result.ticket.model_dump())
+    assert result.ticket.document_type == "buy-ticket"
+    assert [allocation.ticker for allocation in result.ticket.allocations] == [
+        "TSLA",
+        "PLTR",
+        "SPY",
+    ]
+    assert result.guardrails.status == "accepted"
+    assert result.usage.cache_read_input_tokens == 0
+
+    call = client.messages.calls[0]
+    assert call["model"] == "claude-sonnet-4-6"
+    assert call["tool_choice"] == {
+        "type": "tool",
+        "name": "emit_buy_ticket",
+        "disable_parallel_tool_use": True,
+    }
+    assert call["tools"][0]["name"] == "emit_buy_ticket"
+    assert any(
+        block.get("cache_control", {}).get("type") == "ephemeral"
+        for block in call["system"]
+    )
+
+
+def test_ticket_schema_rejects_mismatched_deployment_total() -> None:
+    """Allocation dollars must match deployment_amount before guardrails run."""
+    payload = _ticket_payload()
+    payload["deployment_amount"] = 99999.0
+
+    with pytest.raises(ValueError, match="allocation amounts"):
+        BuyTicket.model_validate(payload)
+
+
+def test_second_identical_generation_reports_prompt_cache_hit() -> None:
+    """The second identical input exposes Anthropic cache-read usage metadata."""
+    client = FakeAnthropicClient(cache_reads=[0, 1200])
+    bundle = _layer3_bundle()
+    portfolio = _portfolio_state()
+
+    first = generate(bundle, portfolio, client=client)
+    second = generate(bundle, portfolio, client=client)
+
+    assert first.usage.cache_read_input_tokens == 0
+    assert second.usage.cache_read_input_tokens == 1200
+    assert len(client.messages.calls) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,38 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.107.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/f1/c6076a92e0bf6b0dfa126e213b3f9e8a510acd73567953210713aae6c256/anthropic-0.107.1.tar.gz", hash = "sha256:8e7169a6ab57fb806b778d9af018c867bad688144efec8969cdb4c5ccecd6670", size = 856312, upload-time = "2026-06-07T17:18:57.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0e/71432f0777a263701955a23ebcc6650485c2753be9afbce2a6a8d72526e3/anthropic-0.107.1-py3-none-any.whl", hash = "sha256:b74338d08000ba105dfc8adae29af3713ece845a4bffec9986a20697e087c7b3", size = 838729, upload-time = "2026-06-07T17:18:58.729Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -646,6 +678,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -680,6 +730,7 @@ name = "family-office"
 version = "2.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "matplotlib" },
     { name = "numpy" },
@@ -732,6 +783,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.107.1" },
     { name = "beautifulsoup4", specifier = ">=4.13.5" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.3.3" },
@@ -1041,6 +1093,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1095,6 +1184,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
 ]
 
 [[package]]
@@ -2899,6 +3060,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- [x] Adds structured AOJ-461 ticket generation with forced JSON tool output.
- [x] Adds post-generation hard guardrail validation and schema consistency checks.
- [x] Adds focused acceptance coverage for guardrail blocking and prompt-cache usage.

## Related

AOJ-461

## Test Plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/`
- [x] `uv run mypy buy_ticket_agent`
- [x] `uv run pytest tests/test_guardrails.py tests/test_ticket_generator.py`
- [x] `uv run pytest tests/test_pipeline.py`
- [x] `uv run pytest tests/python/test_buy_ticket_agent_smoke.py --no-cov`
- [x] `uv run pytest -q -m "not integration"` with a local Bun shim for machine-specific Bun CLI behavior (`948 passed, 1 skipped`)
- [x] `uv export --format requirements.txt --no-hashes --no-emit-project --frozen | diff -u requirements.txt -`

## Review Checklist

- [x] No secrets or PII committed
- [x] Documentation updated (if applicable)
- [x] Test coverage maintained or improved

Local review: local-only changed-scope self-review and privacy review completed under the amended privacy-first gate.
