### PR TITLE
AOJ-461: Scrub system-owned advisory fields

### DIFF
--- a/buy_ticket_agent/guardrails.py
+++ b/buy_ticket_agent/guardrails.py
@@ -95,9 +95,10 @@ def check(
         if violation is not None
     ]
     if not violations:
+        accepted_ticket = parsed_ticket.model_copy(update={"advisory_block": None})
         return GuardrailResult(
             status="accepted",
-            ticket=parsed_ticket,
+            ticket=accepted_ticket,
             advisory_block=None,
             violations=[],
         )

--- a/buy_ticket_agent/ticket_generator.py
+++ b/buy_ticket_agent/ticket_generator.py
@@ -13,6 +13,7 @@ from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState
 
 DEFAULT_MODEL = "claude-sonnet-4-6"
 TICKET_TOOL_NAME = "emit_buy_ticket"
+SYSTEM_MANAGED_TICKET_FIELDS = frozenset({"advisory_block"})
 FRAMEWORK_DOC_PATHS = (
     "fin-guru/templates/buy-ticket-template.md",
     "fin-guru/data/definitions.md",
@@ -95,10 +96,25 @@ def _system_blocks(
 
 
 def _tool_schema() -> dict[str, Any]:
+    input_schema = BuyTicket.model_json_schema()
+    properties = input_schema.get("properties")
+    if isinstance(properties, dict):
+        input_schema["properties"] = {
+            field_name: schema
+            for field_name, schema in properties.items()
+            if field_name not in SYSTEM_MANAGED_TICKET_FIELDS
+        }
+    required = input_schema.get("required")
+    if isinstance(required, list):
+        input_schema["required"] = [
+            field_name
+            for field_name in required
+            if field_name not in SYSTEM_MANAGED_TICKET_FIELDS
+        ]
     return {
         "name": TICKET_TOOL_NAME,
         "description": "Emit one structured buy-ticket JSON object.",
-        "input_schema": BuyTicket.model_json_schema(),
+        "input_schema": input_schema,
     }
 
 

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -102,7 +102,9 @@ def test_check_sums_duplicate_normalized_positions_before_concentration() -> Non
 
 def test_check_accepts_ticket_within_all_hard_limits() -> None:
     """A ticket within every hard threshold is accepted without violations."""
-    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=20000.0)
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=20000.0).model_copy(
+        update={"advisory_block": "llm-authored advisory"}
+    )
     portfolio = PortfolioState(
         portfolio_value=100000.0,
         cash_available=20000.0,

--- a/tests/test_ticket_generator.py
+++ b/tests/test_ticket_generator.py
@@ -114,8 +114,14 @@ def _portfolio_state() -> PortfolioState:
 class FakeMessages:
     """Capture Anthropic request payloads and return forced tool-use blocks."""
 
-    def __init__(self, cache_reads: list[int]) -> None:
+    def __init__(
+        self,
+        cache_reads: list[int],
+        *,
+        tool_input: dict[str, Any] | None = None,
+    ) -> None:
         self.cache_reads = cache_reads
+        self.tool_input = tool_input
         self.calls: list[dict[str, Any]] = []
 
     def create(self, **kwargs: Any) -> SimpleNamespace:
@@ -126,7 +132,9 @@ class FakeMessages:
                 SimpleNamespace(
                     type="tool_use",
                     name="emit_buy_ticket",
-                    input=_ticket_payload(),
+                    input=self.tool_input
+                    if self.tool_input is not None
+                    else _ticket_payload(),
                 )
             ],
             usage=SimpleNamespace(
@@ -141,8 +149,13 @@ class FakeMessages:
 class FakeAnthropicClient:
     """Minimal fake client exposing the SDK messages namespace."""
 
-    def __init__(self, cache_reads: list[int]) -> None:
-        self.messages = FakeMessages(cache_reads)
+    def __init__(
+        self,
+        cache_reads: list[int],
+        *,
+        tool_input: dict[str, Any] | None = None,
+    ) -> None:
+        self.messages = FakeMessages(cache_reads, tool_input=tool_input)
 
 
 def test_generate_calls_claude_with_prompt_cache_and_returns_valid_ticket() -> None:
@@ -169,6 +182,9 @@ def test_generate_calls_claude_with_prompt_cache_and_returns_valid_ticket() -> N
         "disable_parallel_tool_use": True,
     }
     assert call["tools"][0]["name"] == "emit_buy_ticket"
+    input_schema = call["tools"][0]["input_schema"]
+    assert "advisory_block" not in input_schema["properties"]
+    assert "advisory_block" not in input_schema.get("required", [])
     assert any(
         block.get("cache_control", {}).get("type") == "ephemeral"
         for block in call["system"]
@@ -196,3 +212,15 @@ def test_second_identical_generation_reports_prompt_cache_hit() -> None:
     assert first.usage.cache_read_input_tokens == 0
     assert second.usage.cache_read_input_tokens == 1200
     assert len(client.messages.calls) == 2
+
+
+def test_generate_clears_llm_authored_advisory_block_on_accepted_ticket() -> None:
+    """System-owned advisory blocks cannot persist on accepted LLM output."""
+    payload = {**_ticket_payload(), "advisory_block": "llm-authored advisory"}
+    client = FakeAnthropicClient(cache_reads=[0], tool_input=payload)
+
+    result = generate(_layer3_bundle(), _portfolio_state(), client=client)
+
+    assert result.guardrails.status == "accepted"
+    assert result.guardrails.advisory_block is None
+    assert result.ticket.advisory_block is None


### PR DESCRIPTION
## Summary
- AOJ-461: clears system-owned advisory fields on accepted guardrail results
- removes system-owned advisory fields from the LLM-facing tool schema
- adds regression coverage for schema exclusion and accepted-result scrubbing

## Validation
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src/
- uv run mypy buy_ticket_agent
- uv run pytest -m "not integration" tests/test_guardrails.py tests/test_ticket_generator.py
- uv run pytest -m "not integration"
- CodeRabbit CLI review: 0 issues
- Privacy review: sanitized AOJ-only public text

No issue required