### PR TITLE
fix: ITC guardrail bypassed when ITC CLI fails and score is missing

### DIFF
--- a/buy_ticket_agent/guardrails.py
+++ b/buy_ticket_agent/guardrails.py
@@ -70,6 +70,10 @@ def _margin_coverage_violation(portfolio: PortfolioState) -> str | None:
 
 
 def _itc_risk_violation(ticket: BuyTicket) -> str | None:
+    if ticket.itc_applicability == "supported" and ticket.itc_risk_score is None:
+        # ITC was declared applicable but no score arrived (e.g. ITC CLI failure).
+        # Fail-safe: block rather than silently skip the guardrail.
+        return "itc_risk_score_missing"
     if ticket.itc_risk_score is None:
         return None
     if ticket.itc_risk_score >= MAX_ITC_RISK:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -209,3 +209,23 @@ def test_check_accepts_ticket_when_itc_is_not_supported_and_score_is_missing() -
 
     assert result.status == "accepted"
     assert result.advisory_block is None
+
+
+def test_check_accepts_ticket_when_itc_is_unsupported_and_score_is_missing() -> None:
+    """Unsupported ITC applicability with a None score is not a violation."""
+    ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=20000.0).model_copy(
+        update={"itc_applicability": "unsupported", "itc_risk_score": None}
+    )
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=100000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "accepted"
+    assert result.advisory_block is None

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -160,3 +160,52 @@ def test_check_rejects_ticket_when_itc_risk_is_at_hard_limit() -> None:
     assert result.status == "blocked"
     assert result.advisory_block == "itc_risk>=0.7"
     assert result.ticket.advisory_block == "itc_risk>=0.7"
+
+
+def test_check_rejects_ticket_when_itc_is_supported_but_score_is_missing() -> None:
+    """ITC-supported tickets require a risk score; a None score is hard-blocked.
+
+    Realistic trigger: the ITC CLI fails during Layer 3 pipeline execution so the
+    bundle carries itc.data=null.  The LLM faithfully emits
+    itc_applicability='supported' (tradfi asset) but itc_risk_score=null because no
+    score was available.  Without this guard the guardrail would silently pass.
+    """
+    ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=20000.0).model_copy(
+        update={"itc_risk_score": None}
+    )
+    # _ticket_with_allocation always sets itc_applicability="supported".
+    assert ticket.itc_applicability == "supported"
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=100000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "itc_risk_score_missing"
+    assert result.ticket.advisory_block == "itc_risk_score_missing"
+
+
+def test_check_accepts_ticket_when_itc_is_not_supported_and_score_is_missing() -> None:
+    """Non-supported ITC applicability with a None score is not a violation."""
+    ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=20000.0).model_copy(
+        update={"itc_applicability": "not-run", "itc_risk_score": None}
+    )
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=100000.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, portfolio)
+
+    assert result.status == "accepted"
+    assert result.advisory_block is None


### PR DESCRIPTION
## Bug & Impact

The ITC risk guardrail in `guardrails._itc_risk_violation` silently passed — returning no violation — whenever `itc_risk_score` was `None`, regardless of `itc_applicability`. When the Layer 3 ITC CLI fails at runtime (subprocess error, timeout, network issue), the pipeline bundle carries `itc.data = null`. The LLM faithfully emits `itc_applicability='supported'` (correct for a tradfi asset) but `itc_risk_score=null` because no score was available. The guardrail then approved the ticket without any ITC risk having been evaluated, directly contradicting the "non-negotiable post-LLM guardrails" contract.

## Root Cause

`buy_ticket_agent/guardrails.py` line 72–77 (pre-fix):

```python
def _itc_risk_violation(ticket: BuyTicket) -> str | None:
    if ticket.itc_risk_score is None:   # ← passes on None regardless of applicability
        return None
    if ticket.itc_risk_score >= MAX_ITC_RISK:
        return "itc_risk>=0.7"
    return None
```

The early-return for `None` predates the `itc_applicability` field and never distinguished between "ITC was not run / not applicable" (correct to skip) and "ITC was run but the score is absent due to tool failure" (should block).

## Trigger Scenario

1. `pipeline.run(["TSLA"], universe="tradfi")` executes the Layer 3 CLI matrix.
2. The ITC CLI subprocess fails (`ProcessFailed`, `TimeoutExpired`, or `FileNotFoundError`) → `Layer3ToolResult(key="itc", status="failed", data=None)`.
3. `ticket_generator.generate()` calls the LLM with the bundle; the LLM sets `itc_applicability="supported"` (tradfi, correct) and `itc_risk_score=null` (no data, also correct given the bundle).
4. `BuyTicket.model_validate(...)` succeeds — `itc_risk_score: float | None = None` is valid.
5. `guardrails.check()` calls `_itc_risk_violation` → returns `None` (no violation).
6. Ticket status: **accepted** — despite ITC risk never being evaluated.

## Fix

Added one guard before the existing `None` short-circuit:

```python
def _itc_risk_violation(ticket: BuyTicket) -> str | None:
    if ticket.itc_applicability == "supported" and ticket.itc_risk_score is None:
        return "itc_risk_score_missing"   # fail-safe: ITC applicable but score absent
    if ticket.itc_risk_score is None:
        return None                        # "unsupported" / "not-run" — no check needed
    if ticket.itc_risk_score >= MAX_ITC_RISK:
        return "itc_risk>=0.7"
    return None
```

`itc_applicability="unsupported"` and `"not-run"` continue to pass through with a `None` score as before.

## Validation

- **pytest**: 951 passed, 3 skipped (baseline 949 + 2 new tests)
- **ruff**: All checks passed
- **mypy**: Success: no issues found in 91 source files
- **New tests**:
  - `test_check_rejects_ticket_when_itc_is_supported_but_score_is_missing` — confirms the ITC CLI failure path is now blocked
  - `test_check_accepts_ticket_when_itc_is_not_supported_and_score_is_missing` — confirms non-applicable ITC still passes with a `None` score

---
_Generated by [Claude Code](https://claude.ai/code/session_015fU2Rb1nC2Yz5HeJw6AT7q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tickets are now rejected when ITC applicability indicates a supported check but the ITC risk score is missing; the ticket is hard-blocked and a clear advisory flag notes the missing score.
  * Tickets remain accepted when ITC applicability indicates the check was not run or is unsupported, even if the score is absent.

* **Tests**
  * Added coverage validating the above ITC acceptance/rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->