### PR TITLE
fix: make Black-Litterman views unit-consistent

### DIFF
--- a/src/strategies/optimizer.py
+++ b/src/strategies/optimizer.py
@@ -496,7 +496,7 @@ class PortfolioOptimizer:
         # Assume equal weights as proxy for market cap weights
         market_weights = np.array([1.0 / n_assets] * n_assets)
         risk_aversion = 2.5  # Typical value
-        equilibrium_returns = risk_aversion * cov_matrix @ market_weights
+        equilibrium_excess_returns = risk_aversion * cov_matrix @ market_weights
 
         # Step 2: Incorporate investor views
         # For simplicity, we'll use absolute views (each view is independent)
@@ -506,16 +506,19 @@ class PortfolioOptimizer:
         # Build view vector Q (what are the views)
         view_tickers = list(self.config.views.keys())
         P = np.zeros((len(view_tickers), n_assets))
-        Q = np.zeros(len(view_tickers))
+        view_excess_returns = np.zeros(len(view_tickers))
 
         for i, view_ticker in enumerate(view_tickers):
             ticker_idx = data.tickers.index(view_ticker)
             P[i, ticker_idx] = 1.0
-            Q[i] = self.config.views[view_ticker]
+            view_excess_returns[i] = (
+                self.config.views[view_ticker] - self.config.risk_free_rate
+            )
 
-        # View uncertainty (omega) - proportional to variance
-        # Higher variance = less confidence in view
-        Omega = np.diag([P[i] @ cov_matrix @ P[i].T for i in range(len(view_tickers))])
+        # Scale view uncertainty with tau so views and equilibrium share units.
+        Omega = tau * np.diag(
+            [P[i] @ cov_matrix @ P[i].T for i in range(len(view_tickers))]
+        )
 
         # Step 3: Compute posterior (blended) returns
         # Posterior = [(τΣ)^-1 + P^T Ω^-1 P]^-1 [(τΣ)^-1 π + P^T Ω^-1 Q]
@@ -525,13 +528,15 @@ class PortfolioOptimizer:
         posterior_precision = tau_cov_inv + P.T @ omega_inv @ P
         posterior_cov = np.linalg.inv(posterior_precision)
 
-        posterior_returns = posterior_cov @ (
-            tau_cov_inv @ equilibrium_returns + P.T @ omega_inv @ Q
+        posterior_excess_returns = posterior_cov @ (
+            tau_cov_inv @ equilibrium_excess_returns
+            + P.T @ omega_inv @ view_excess_returns
         )
 
-        # Step 4: Optimize using posterior returns (standard mean-variance)
+        # Step 4: Maximize mean-variance utility using posterior excess returns.
         def objective(weights):
-            return weights @ cov_matrix @ weights
+            variance_penalty = 0.5 * risk_aversion * (weights @ cov_matrix @ weights)
+            return variance_penalty - weights @ posterior_excess_returns
 
         constraints = [{"type": "eq", "fun": lambda w: np.sum(w) - 1.0}]
 
@@ -552,6 +557,7 @@ class PortfolioOptimizer:
             raise ValueError(f"Black-Litterman optimization failed: {result.message}")
 
         weights = self._validate_weights(result.x, data.tickers)
+        posterior_returns = posterior_excess_returns + self.config.risk_free_rate
         return self._create_output(weights, data, posterior_returns, cov_matrix)
 
     def generate_efficient_frontier(

--- a/src/strategies/optimizer.py
+++ b/src/strategies/optimizer.py
@@ -534,9 +534,10 @@ class PortfolioOptimizer:
         )
 
         # Step 4: Maximize mean-variance utility using posterior excess returns.
-        def objective(weights):
+        def objective(weights: np.ndarray) -> float:
+            """Return negative posterior mean-variance utility."""
             variance_penalty = 0.5 * risk_aversion * (weights @ cov_matrix @ weights)
-            return variance_penalty - weights @ posterior_excess_returns
+            return float(variance_penalty - weights @ posterior_excess_returns)
 
         constraints = [{"type": "eq", "fun": lambda w: np.sum(w) - 1.0}]
 

--- a/tests/python/test_optimizer.py
+++ b/tests/python/test_optimizer.py
@@ -51,6 +51,20 @@ def _make_portfolio_data(n_days=60, tickers=None, seed=42):
     )
 
 
+def _make_two_volatility_assets():
+    """Build deterministic low/high-volatility assets."""
+    rng = np.random.RandomState(7)
+    dates = [date(2024, 1, 1) + timedelta(days=i) for i in range(300)]
+    prices = {}
+    for ticker, annual_vol in (("LOW", 0.10), ("HIGH", 0.40)):
+        returns = rng.normal(0.0002, annual_vol / np.sqrt(252), len(dates))
+        series = [100.0]
+        for value in returns[1:]:
+            series.append(series[-1] * (1 + value))
+        prices[ticker] = series
+    return PortfolioDataInput(tickers=["LOW", "HIGH"], dates=dates, prices=prices)
+
+
 @pytest.fixture
 def portfolio_data():
     return _make_portfolio_data()
@@ -179,6 +193,35 @@ class TestBlackLitterman:
         # OptimizationConfig should raise if BL without views
         with pytest.raises(ValueError, match="views"):
             OptimizationConfig(method="black_litterman", views=None)
+
+    def test_bl_realistic_views_reverse_the_tilt(self):
+        data = _make_two_volatility_assets()
+        low_bull = PortfolioOptimizer(
+            OptimizationConfig(
+                method="black_litterman", views={"LOW": 0.15, "HIGH": 0.05}
+            )
+        ).optimize(data)
+        high_bull = PortfolioOptimizer(
+            OptimizationConfig(
+                method="black_litterman", views={"LOW": 0.05, "HIGH": 0.15}
+            )
+        ).optimize(data)
+        assert low_bull.optimal_weights["LOW"] > high_bull.optimal_weights["LOW"]
+        assert high_bull.optimal_weights["HIGH"] > low_bull.optimal_weights["HIGH"]
+
+    def test_bl_equilibrium_views_recover_market_proxy(self):
+        data = _make_two_volatility_assets()
+        seed = OptimizationConfig(
+            method="black_litterman", views={"LOW": 0.05, "HIGH": 0.05}
+        )
+        optimizer = PortfolioOptimizer(seed)
+        covariance = optimizer._calculate_covariance_matrix(data)
+        equilibrium = 2.5 * covariance @ np.array([0.5, 0.5])
+        views = dict(zip(data.tickers, equilibrium + seed.risk_free_rate, strict=True))
+        result = PortfolioOptimizer(seed.model_copy(update={"views": views})).optimize(
+            data
+        )
+        assert result.optimal_weights["LOW"] == pytest.approx(0.5, abs=0.03)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Treat reverse-optimized equilibrium returns as excess returns.
- Convert configured absolute annual views to excess returns before blending.
- Scale view uncertainty with tau and optimize posterior excess returns with the existing risk-aversion convention.
- Add realistic view-reversal and equilibrium-recovery regressions.

Fixes #98

## Root cause

Main computed posterior returns but minimized variance only, so views did not influence weights. The Cursor candidate in #91 switched to max-Sharpe but mixed excess equilibrium returns with absolute views and subtracted the risk-free rate twice.

## Validation

- uv run pytest tests/python/test_optimizer.py -q --no-cov -n0 — 24 passed
- uv run pytest -q — 989 passed, 3 skipped; 83.59% coverage
- uv run ruff format --check . — passed
- uv run ruff check . — passed
- uv run mypy src/ — passed
- git diff --check — passed
- pre-commit hooks — passed

## Scope

This PR contains only the Black-Litterman repair. The risk-parity correction remains separate in #91 / #97.

Generated with OpenAI Codex; I reviewed the implementation, ran the required gates, and verified both discriminating allocation behaviors before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved Black-Litterman portfolio optimization by incorporating the risk-free rate into both equilibrium and investor view return estimates.
  * Updated the optimization to better balance expected excess returns against portfolio risk, leading to more consistent weight tilts when views change.
  * Portfolio outputs continue to present returns in absolute terms for easier interpretation.
* **Tests**
  * Expanded Black-Litterman coverage with deterministic synthetic scenarios to verify view inversion behavior and recovery of expected near-equal allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->