### PR TITLE
security: scrub PII from HEAD and stop the scanner passing blind

### DIFF
--- a/.claude/skills/TransactionSyncing/workflows/IngestTransactions.md
+++ b/.claude/skills/TransactionSyncing/workflows/IngestTransactions.md
@@ -5,17 +5,17 @@ Ingest Fidelity transaction history CSV from Downloads into the local rolling ar
 ## Triggers
 
 - "ingest transactions", "import history", "bring in transactions"
-- User points to `~/Downloads/History_for_Account_Z05724592.csv`
+- User points to `~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv`
 - User mentions downloading transaction history from Fidelity
 
 ## Step 1: Locate Source File
 
-**Default location**: `~/Downloads/History_for_Account_Z05724592.csv`
+**Default location**: `~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv`
 **Alternative**: User may specify a different path.
 
 ```bash
 # Verify file exists
-ls -la ~/Downloads/History_for_Account_Z05724592.csv
+ls -la ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv
 ```
 
 If not found, ask user for the file location.
@@ -51,17 +51,17 @@ awk -F',' 'NR>2 && $1 ~ /^[0-9]/ {count++} END {print count}' "$SOURCE_FILE"
 
 **Destination**: `notebooks/transactions/`
 
-**Naming convention**: `History_for_Account_Z05724592_{YYYY-MM-DD}_{period}.csv`
+**Naming convention**: `History_for_Account_REDACTED_ACCOUNT_{YYYY-MM-DD}_{period}.csv`
 
 Where:
 - `{YYYY-MM-DD}` = the download/run date (latest date in file, or today's date)
 - `{period}` = `30d`, `60d`, or `{N}d`
 
-**Example**: `History_for_Account_Z05724592_2026-03-06_60d.csv`
+**Example**: `History_for_Account_REDACTED_ACCOUNT_2026-03-06_60d.csv`
 
 ```bash
-cp ~/Downloads/History_for_Account_Z05724592.csv \
-   notebooks/transactions/History_for_Account_Z05724592_2026-03-06_60d.csv
+cp ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv \
+   notebooks/transactions/History_for_Account_REDACTED_ACCOUNT_2026-03-06_60d.csv
 ```
 
 ## Step 4: Merge into Accounts_History.csv
@@ -117,11 +117,11 @@ If `Accounts_History.csv` doesn't exist:
 
 ## Step 5: Update notebooks/updates/ Copy
 
-After merging, also update `notebooks/updates/History_for_Account_Z05724592.csv` with the latest download so other skills (dividend-tracking, etc.) can reference it:
+After merging, also update `notebooks/updates/History_for_Account_REDACTED_ACCOUNT.csv` with the latest download so other skills (dividend-tracking, etc.) can reference it:
 
 ```bash
-cp ~/Downloads/History_for_Account_Z05724592.csv \
-   notebooks/updates/History_for_Account_Z05724592.csv
+cp ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv \
+   notebooks/updates/History_for_Account_REDACTED_ACCOUNT.csv
 ```
 
 ## Step 6: Extract Dividend Summary
@@ -145,9 +145,9 @@ This data supplements (not replaces) the dividends.csv forward-looking projectio
 TRANSACTION INGESTION COMPLETE - {date}
 ---
 
-SOURCE: ~/Downloads/History_for_Account_Z05724592.csv
+SOURCE: ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv
 PERIOD: {earliest_date} to {latest_date} ({N}d)
-ARCHIVED AS: History_for_Account_Z05724592_{date}_{period}.csv
+ARCHIVED AS: History_for_Account_REDACTED_ACCOUNT_{date}_{period}.csv
 
 MERGE RESULTS:
   New rows added to Accounts_History: XX
@@ -182,7 +182,7 @@ This may indicate a missing export period. Consider downloading that range.
 
 ### File not found
 ```
-Source file not found at ~/Downloads/History_for_Account_Z05724592.csv
+Source file not found at ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv
 Please download your transaction history from Fidelity (last 30 or 60 days).
 ```
 
@@ -195,7 +195,7 @@ Please verify this is a Fidelity History export.
 ```
 
 ### Duplicate archive name
-If `History_for_Account_Z05724592_{date}_{period}.csv` already exists:
+If `History_for_Account_REDACTED_ACCOUNT_{date}_{period}.csv` already exists:
 - Compare file sizes. If identical, skip copy.
 - If different, append a counter: `..._2026-03-06_60d_2.csv`
 

--- a/.claude/skills/TransactionSyncing/workflows/IngestTransactions.md
+++ b/.claude/skills/TransactionSyncing/workflows/IngestTransactions.md
@@ -5,17 +5,17 @@ Ingest Fidelity transaction history CSV from Downloads into the local rolling ar
 ## Triggers
 
 - "ingest transactions", "import history", "bring in transactions"
-- User points to `~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv`
+- User points to `~/Downloads/History_for_Account_{account_id}.csv`
 - User mentions downloading transaction history from Fidelity
 
 ## Step 1: Locate Source File
 
-**Default location**: `~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv`
+**Default location**: `~/Downloads/History_for_Account_{account_id}.csv`
 **Alternative**: User may specify a different path.
 
 ```bash
 # Verify file exists
-ls -la ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv
+ls -la ~/Downloads/History_for_Account_{account_id}.csv
 ```
 
 If not found, ask user for the file location.
@@ -51,17 +51,17 @@ awk -F',' 'NR>2 && $1 ~ /^[0-9]/ {count++} END {print count}' "$SOURCE_FILE"
 
 **Destination**: `notebooks/transactions/`
 
-**Naming convention**: `History_for_Account_REDACTED_ACCOUNT_{YYYY-MM-DD}_{period}.csv`
+**Naming convention**: `History_for_Account_{account_id}_{YYYY-MM-DD}_{period}.csv`
 
 Where:
 - `{YYYY-MM-DD}` = the download/run date (latest date in file, or today's date)
 - `{period}` = `30d`, `60d`, or `{N}d`
 
-**Example**: `History_for_Account_REDACTED_ACCOUNT_2026-03-06_60d.csv`
+**Example**: `History_for_Account_{account_id}_2026-03-06_60d.csv`
 
 ```bash
-cp ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv \
-   notebooks/transactions/History_for_Account_REDACTED_ACCOUNT_2026-03-06_60d.csv
+cp ~/Downloads/History_for_Account_{account_id}.csv \
+   notebooks/transactions/History_for_Account_{account_id}_2026-03-06_60d.csv
 ```
 
 ## Step 4: Merge into Accounts_History.csv
@@ -117,11 +117,11 @@ If `Accounts_History.csv` doesn't exist:
 
 ## Step 5: Update notebooks/updates/ Copy
 
-After merging, also update `notebooks/updates/History_for_Account_REDACTED_ACCOUNT.csv` with the latest download so other skills (dividend-tracking, etc.) can reference it:
+After merging, also update `notebooks/updates/History_for_Account_{account_id}.csv` with the latest download so other skills (dividend-tracking, etc.) can reference it:
 
 ```bash
-cp ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv \
-   notebooks/updates/History_for_Account_REDACTED_ACCOUNT.csv
+cp ~/Downloads/History_for_Account_{account_id}.csv \
+   notebooks/updates/History_for_Account_{account_id}.csv
 ```
 
 ## Step 6: Extract Dividend Summary
@@ -145,9 +145,9 @@ This data supplements (not replaces) the dividends.csv forward-looking projectio
 TRANSACTION INGESTION COMPLETE - {date}
 ---
 
-SOURCE: ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv
+SOURCE: ~/Downloads/History_for_Account_{account_id}.csv
 PERIOD: {earliest_date} to {latest_date} ({N}d)
-ARCHIVED AS: History_for_Account_REDACTED_ACCOUNT_{date}_{period}.csv
+ARCHIVED AS: History_for_Account_{account_id}_{date}_{period}.csv
 
 MERGE RESULTS:
   New rows added to Accounts_History: XX
@@ -182,7 +182,7 @@ This may indicate a missing export period. Consider downloading that range.
 
 ### File not found
 ```
-Source file not found at ~/Downloads/History_for_Account_REDACTED_ACCOUNT.csv
+Source file not found at ~/Downloads/History_for_Account_{account_id}.csv
 Please download your transaction history from Fidelity (last 30 or 60 days).
 ```
 
@@ -195,7 +195,7 @@ Please verify this is a Fidelity History export.
 ```
 
 ### Duplicate archive name
-If `History_for_Account_REDACTED_ACCOUNT_{date}_{period}.csv` already exists:
+If `History_for_Account_{account_id}_{date}_{period}.csv` already exists:
 - Compare file sizes. If identical, skip copy.
 - If different, append a counter: `..._2026-03-06_60d_2.csv`
 

--- a/.claude/skills/compliance-scan/references/secret-patterns.md
+++ b/.claude/skills/compliance-scan/references/secret-patterns.md
@@ -32,7 +32,7 @@ A HIGH hit means data that identifies the owner, exposes infrastructure, or brea
 
 | Rule | Example | Why high | Fix |
 |------|---------|----------|-----|
-| `fidelity-account` | `Z00000000` (matches `Z0\d{7,}`) | Account number ID | Replace with `{account_id}` template variable |
+| `fidelity-account` | `REDACTED_ACCOUNT` (matches `Z0\d{7,}`) | Account number ID | Replace with `{account_id}` template variable |
 | `ssn` | `NNN-NN-NNNN` | Identity / financial | Move to env, never commit |
 | `apps-script-dispatcher` | `https://script.google.com/macros/s/.../exec` | Live deploy URL — anyone with it can invoke the script | Move URL to `.env`; reference via env var |
 | `google-script-deployment-id` | `AKfyc...` (~55 chars) | Apps Script deploy ID | Same as above — env var only |

--- a/.claude/skills/compliance-scan/references/secret-patterns.md
+++ b/.claude/skills/compliance-scan/references/secret-patterns.md
@@ -32,7 +32,7 @@ A HIGH hit means data that identifies the owner, exposes infrastructure, or brea
 
 | Rule | Example | Why high | Fix |
 |------|---------|----------|-----|
-| `fidelity-account` | `REDACTED_ACCOUNT` (matches `Z0\d{7,}`) | Account number ID | Replace with `{account_id}` template variable |
+| `fidelity-account` | `Z0NNNNNNN` (shape of `Z0\d{7,}`) | Account number ID | Replace with `{account_id}` template variable |
 | `ssn` | `NNN-NN-NNNN` | Identity / financial | Move to env, never commit |
 | `apps-script-dispatcher` | `https://script.google.com/macros/s/.../exec` | Live deploy URL — anyone with it can invoke the script | Move URL to `.env`; reference via env var |
 | `google-script-deployment-id` | `AKfyc...` (~55 chars) | Apps Script deploy ID | Same as above — env var only |

--- a/.claude/skills/compliance-scan/references/test-pii-pattern.md
+++ b/.claude/skills/compliance-scan/references/test-pii-pattern.md
@@ -8,10 +8,10 @@ Some tests pass the actual production values around just to exercise a code path
 
 ```python
 # tests/python/test_margin_metrics.py — current
-csv_path = tmp_path / "Balances_for_Account_Z05724592.csv"
+csv_path = tmp_path / "Balances_for_Account_Z01234567.csv"
 ```
 
-The test doesn't care that the account is `Z05724592`. It cares that the filename matches `Balances_for_Account_<id>.csv`. But committing the literal puts the real account number on GitHub forever.
+The test doesn't care that the account is `Z01234567`. It cares that the filename matches `Balances_for_Account_<id>.csv`. But committing the literal puts the real account number on GitHub forever.
 
 ## The pattern (Python)
 
@@ -62,10 +62,10 @@ tests/python/fixtures/private/
 
 ```yaml
 # tests/python/fixtures/private/values.yaml — NOT committed
-account_id: "Z05724592"
-balance_filename: "Balances_for_Account_Z05724592.csv"
+account_id: "Z01234567"
+balance_filename: "Balances_for_Account_Z01234567.csv"
 positions_filename: "Portfolio_Positions_Nov-05-2025.csv"
-history_filename: "History_for_Account_Z05724592.csv"
+history_filename: "History_for_Account_Z01234567.csv"
 total_account_value: 228809.41
 ```
 
@@ -119,7 +119,7 @@ ACCOUNT_ID="${TEST_ACCOUNT_ID:-Z00000000}"
 ```bash
 # tests/integration/private/values.env — NOT committed
 export TEST_POSITIONS_FILENAME="Portfolio_Positions_Nov-05-2025.csv"
-export TEST_ACCOUNT_ID="Z05724592"
+export TEST_ACCOUNT_ID="Z01234567"
 ```
 
 ## Migration checklist

--- a/.claude/skills/compliance-scan/scripts/install-pre-push.sh
+++ b/.claude/skills/compliance-scan/scripts/install-pre-push.sh
@@ -48,6 +48,28 @@ if ! "$SCAN" --scope push --skip-existing-tests; then
     echo "  - Bypass with: git push --no-verify  (and justify in your commit message)" >&2
     exit 1
 fi
+
+# Standing-exposure warning. The blocking scan above only sees what this push
+# adds, so it is structurally blind to anything already committed. That blind
+# spot let two PII files sit on the public remote for six months (2026-02-04 to
+# 2026-08-11) while every push passed clean.
+#
+# Deliberately NON-blocking: a repo with pre-existing findings would otherwise
+# be unpushable, and an unpushable hook just teaches everyone --no-verify. This
+# reports and gets out of the way. Clear the backlog with:
+#   .claude/skills/compliance-scan/scripts/scan.py --scope tree
+if TREE_OUT="$("$SCAN" --scope tree --skip-existing-tests --format json 2>/dev/null)"; then
+    :
+else
+    COUNT="$(printf '%s' "$TREE_OUT" | grep -o '"severity"' | wc -l | tr -d ' ')"
+    if [[ "${COUNT:-0}" -gt 0 ]]; then
+        echo "" >&2
+        echo "compliance-scan: NOTE — $COUNT standing finding(s) already in the tree." >&2
+        echo "  This push is clean; the repo is not. Audit with:" >&2
+        echo "    $SCAN --scope tree" >&2
+        echo "  (not blocking)" >&2
+    fi
+fi
 HOOK
 
 chmod +x "$HOOK_PATH"

--- a/.claude/skills/compliance-scan/scripts/install-pre-push.sh
+++ b/.claude/skills/compliance-scan/scripts/install-pre-push.sh
@@ -58,17 +58,24 @@ fi
 # be unpushable, and an unpushable hook just teaches everyone --no-verify. This
 # reports and gets out of the way. Clear the backlog with:
 #   .claude/skills/compliance-scan/scripts/scan.py --scope tree
-if TREE_OUT="$("$SCAN" --scope tree --skip-existing-tests --format json 2>/dev/null)"; then
-    :
-else
-    COUNT="$(printf '%s' "$TREE_OUT" | grep -o '"severity"' | wc -l | tr -d ' ')"
-    if [[ "${COUNT:-0}" -gt 0 ]]; then
-        echo "" >&2
-        echo "compliance-scan: NOTE — $COUNT standing finding(s) already in the tree." >&2
-        echo "  This push is clean; the repo is not. Audit with:" >&2
-        echo "    $SCAN --scope tree" >&2
-        echo "  (not blocking)" >&2
-    fi
+# MEDIUM and INFO findings are report-only, so the scanner exits 0 while still
+# returning them. Inspect the JSON on every exit status, not just failure, or
+# the hook stays blind to the exact class it exists to surface. Status 2 means
+# the scanner itself errored (e.g. no pattern source); say so, still don't block.
+TREE_STATUS=0
+TREE_OUT="$("$SCAN" --scope tree --skip-existing-tests --format json 2>/dev/null)" || TREE_STATUS=$?
+COUNT="$(printf '%s' "$TREE_OUT" | grep -o '"severity"' | wc -l | tr -d ' ')" || COUNT=0
+if [[ "${COUNT:-0}" -gt 0 ]]; then
+    echo "" >&2
+    echo "compliance-scan: NOTE — $COUNT standing finding(s) already in the tree." >&2
+    echo "  This push is clean; the repo is not. Audit with:" >&2
+    echo "    $SCAN --scope tree" >&2
+    echo "  (not blocking)" >&2
+elif [[ "$TREE_STATUS" -ne 0 ]]; then
+    echo "" >&2
+    echo "compliance-scan: WARNING — tree scan failed with status $TREE_STATUS." >&2
+    echo "  Audit with: $SCAN --scope tree" >&2
+    echo "  (not blocking)" >&2
 fi
 HOOK
 

--- a/.claude/skills/compliance-scan/scripts/scan.py
+++ b/.claude/skills/compliance-scan/scripts/scan.py
@@ -260,7 +260,28 @@ def load_pii_replacement_patterns(
     """
     path = repo_root / "scripts" / "qa" / "pii-replacements.txt"
     if not path.exists():
-        return []
+        # Loud, not silent. This file is gitignored, so any fresh clone or
+        # worktree lacks it — and returning [] here made the scanner report
+        # "PASS — no findings" with zero patterns loaded. A security gate that
+        # reports clean because it is blind is worse than no gate: it is the
+        # exact failure that let PII sit on the public remote for six months.
+        # Template fallback keeps a fresh clone scanning on the shipped rules.
+        template = path.with_name("pii-replacements.template.txt")
+        if template.exists():
+            print(
+                f"compliance-scan: WARNING — {path.name} missing; falling back to "
+                f"{template.name}. Repo-specific values will NOT be detected.",
+                file=sys.stderr,
+            )
+            path = template
+        else:
+            print(
+                f"compliance-scan: ERROR — no PII pattern source at {path} and no "
+                "template fallback. Refusing to report a pass with zero patterns "
+                "loaded.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
 
     rules: list[tuple[str, re.Pattern[str], str]] = []
     for raw in path.read_text().splitlines():

--- a/docs/solutions/workflow-issues/wrong-dividend-data-source-DividendTracking-20260216.md
+++ b/docs/solutions/workflow-issues/wrong-dividend-data-source-DividendTracking-20260216.md
@@ -49,7 +49,7 @@ Use the transaction history CSV (`History_for_Account_*.csv`) instead, filtering
 # Problem: These are PROJECTED rates, not actual payments
 JEPI, 120.91, $0.4939  # This is a per-share rate estimate
 
-# CORRECT SOURCE: History_for_Account_Z05724592.csv
+# CORRECT SOURCE: History_for_Account_REDACTED_ACCOUNT.csv
 # Contains: Run Date, Action, Symbol, Amount (actual dollars received)
 # Solution: Filter for "DIVIDEND RECEIVED" action type
 01/05/2026, DIVIDEND RECEIVED, JEPI, $46.86  # This is the ACTUAL payment

--- a/fin-guru/tasks/profile-parser.md
+++ b/fin-guru/tasks/profile-parser.md
@@ -19,7 +19,7 @@ EXTRACT:
 - Fixed expenses: $4,500
 - Variable expenses: $10,000
 - Monthly savings: $5,000
-- Mortgage: $365,139.76 balance, $1,712.68/month
+- Mortgage: REDACTED_AMOUNT balance, $1,712.68/month
 - Other debt: 2 car loans, student loans (8%), credit cards
 - Risk profile: Aggressive
 ```
@@ -59,8 +59,8 @@ user_profile:
     investment_capacity: 10500
 
   debt_profile:
-    mortgage_balance: 365139.76
-    mortgage_payment: 1712.68
+    mortgage_balance: REDACTED_AMOUNT
+    mortgage_payment: REDACTED_AMOUNT
     other_debt:
       - type: "student_loans"
         rate: 0.08

--- a/fin-guru/tasks/profile-parser.md
+++ b/fin-guru/tasks/profile-parser.md
@@ -19,7 +19,7 @@ EXTRACT:
 - Fixed expenses: $4,500
 - Variable expenses: $10,000
 - Monthly savings: $5,000
-- Mortgage: REDACTED_AMOUNT balance, $1,712.68/month
+- Mortgage: REDACTED_AMOUNT balance, REDACTED_AMOUNT/month
 - Other debt: 2 car loans, student loans (8%), credit cards
 - Risk profile: Aggressive
 ```
@@ -59,8 +59,8 @@ user_profile:
     investment_capacity: 10500
 
   debt_profile:
-    mortgage_balance: REDACTED_AMOUNT
-    mortgage_payment: REDACTED_AMOUNT
+    mortgage_balance: 250000.42
+    mortgage_payment: 1500.33
     other_debt:
       - type: "student_loans"
         rate: 0.08

--- a/tests/onboarding/broker-types.test.ts
+++ b/tests/onboarding/broker-types.test.ts
@@ -134,7 +134,7 @@ describe('Broker Interfaces', () => {
       netDebit: -7822.71,
       accountEquityPercentage: 96.58,
       marginInterestAccrued: 0,
-      totalAccountValue: 228809.41
+      totalAccountValue: 100000.55
     };
 
     expect(balances.settledCash).toBe(0);
@@ -152,7 +152,7 @@ describe('Broker Interfaces', () => {
         netDebit: -7822.71,
         accountEquityPercentage: 96.58,
         marginInterestAccrued: 0,
-        totalAccountValue: 228809.41
+        totalAccountValue: 100000.55
       },
       broker: 'fidelity' as BrokerType,
       exportDate: new Date()
@@ -160,6 +160,6 @@ describe('Broker Interfaces', () => {
 
     expect(data.broker).toBe('fidelity');
     expect(data.positions.length).toBe(1);
-    expect(data.balances.totalAccountValue).toBe(228809.41);
+    expect(data.balances.totalAccountValue).toBe(100000.55);
   });
 });

--- a/tests/python/test_debt_profile_section.py
+++ b/tests/python/test_debt_profile_section.py
@@ -172,15 +172,15 @@ class TestDebtProfileSection:
                 "-e",
                 """
             import { validateCurrency } from './scripts/onboarding/modules/input-validator.ts';
-            console.log(validateCurrency('365139.76'));
-            console.log(validateCurrency('$1,712.68'));
+            console.log(validateCurrency('250000.42'));
+            console.log(validateCurrency('$1,500.33'));
             """,
             ],
             capture_output=True,
             text=True,
         )
         assert result.returncode == 0
-        assert "365139.76" in result.stdout
+        assert "250000.42" in result.stdout
 
     def test_percentage_validation_integration(self):
         """Test that percentage validation is properly integrated"""

--- a/tests/python/test_onboarding_summary.py
+++ b/tests/python/test_onboarding_summary.py
@@ -66,8 +66,8 @@ class TestSummarySection:
                     "investment_capacity": 10500,
                 },
                 "debt": {
-                    "mortgage_balance": 365139.76,
-                    "mortgage_payment": 1712.68,
+                    "mortgage_balance": 250000.42,
+                    "mortgage_payment": 1500.33,
                     "other_debt": [{"type": "student_loans", "rate": 0.08}],
                 },
                 "preferences": {

--- a/tests/python/test_preferences_section.py
+++ b/tests/python/test_preferences_section.py
@@ -55,8 +55,8 @@ class TestPreferencesSection:
                     "investment_capacity": 10500,
                 },
                 "debt": {
-                    "mortgage_balance": 365139.76,
-                    "mortgage_payment": 1712.68,
+                    "mortgage_balance": 250000.42,
+                    "mortgage_payment": 1500.33,
                     "other_debt": [],
                 },
             },


### PR DESCRIPTION
Stacks on #122.

A full-tree scan (`--scope tree` — which nothing was running) found **121 findings across 28 tracked files**. Those collapse to **22 distinct values**, not 121 secrets.

### Scrubbed
Account numbers, dollar amounts, employer names, entity names, the spreadsheet id, and the already-rotated API token.

- **Docs** get `REDACTED_*` tokens.
- **Executable fixtures** get *synthetic values* instead — `mortgage_balance: REDACTED_AMOUNT` is a `NameError`, not a redaction. Synthetic amounts use non-round decimals because `validateCurrency` normalises `"250000.00"` → `"250000"`, which broke a substring assertion on the first attempt.
- `test-pii-pattern.md` is hand-edited, not bulk-substituted: it documents this exact failure mode, so it needed a synthetic account number while keeping `Z00000000` — its own safe-placeholder example — intact.

### Deliberately not scrubbed
The repo owner's name, GitHub handle, and email. This is a public repo published under that identity; redacting it would break `.github/FUNDING.yml` and hide nothing. The 64 remaining findings are all that class.

### Two gate fixes
- `install-pre-push.sh` now reports standing tree findings after the blocking push scan. The blocking scan only sees what a push *adds* — structurally blind to what is already committed, which is how this sat for six months. **Non-blocking on purpose**: a repo with a backlog would otherwise be unpushable, and an unpushable hook just teaches `--no-verify`.
- `scan.py` no longer returns `[]` when `pii-replacements.txt` is missing. That file is gitignored, so every fresh clone/worktree lacked it and the scanner reported **"PASS — no findings" with zero patterns loaded**. Now falls back to the tracked template with a warning, or exits 2. Found by tripping over it mid-change.

### Tests
`1005 passed, 1 skipped` (pytest) · `17 pass, 0 fail` (bun).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Privacy**
  * Redacted exposed account identifiers and financial amounts from workflow examples, documentation, and test fixtures.
  * Updated compliance examples to use safe placeholder values.

* **Compliance**
  * Added a non-blocking repository-wide compliance scan during pre-push checks.
  * Scanning now warns and falls back to template rules when repository-specific patterns are unavailable, or reports a clear error when no rules exist.

* **Tests**
  * Refreshed financial and account-value test scenarios with non-sensitive sample data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->