### PR TITLE
fix(simplefin): correct transaction direction, payroll tagging, and 401(k) categorization

### DIFF
--- a/.claude/skills/PortfolioSyncing/SKILL.md
+++ b/.claude/skills/PortfolioSyncing/SKILL.md
@@ -65,6 +65,40 @@ sqlite3 family_office.db "SELECT * FROM balances;"
 - If settled cash is 0, SPAXX is $0 (all funds invested or in margin).
 - "Cash market value" is NOT cash; it is the value of positions held in the Cash account rather than the Margin account.
 
+## Price Freshness: SnapTrade marks lag one session
+
+**A successful sync does not mean current prices.** SnapTrade publishes `price` on
+each position from the prior session's close, so `account_equity` and
+`gross_market_value` are stale by one trading day even when `synced_at` is the
+current timestamp. Verified 2026-08-04: two syncs, at 17:46 and 17:53 CT (well
+after the 15:00 CT close), both returned Aug 3 closes on all six spot-checked
+tickers. PLTR read $125.65 against an actual Aug 4 close of $162.66.
+
+What this means in practice:
+
+- **Structurally reliable**: holdings, quantities, cost basis, settled cash,
+  margin debt. Use the DB for all of these.
+- **Lagging**: `price`, `account_equity`, `gross_market_value`, and every ratio
+  derived from them (equity-to-debt, gross-to-debt, position weights).
+
+**On any day with a material move, mark to market before reasoning off the
+snapshot.** On 2026-08-04 the as-synced equity of $188,859 understated the real
+$204,753 by $15,894, and equity-to-debt read 2.206x when it was actually 2.392x.
+That is the difference between "still in breach" and "approaching the gate".
+
+Check freshness by comparing a couple of DB prices to the live close:
+
+```bash
+uv run python -c "
+import sqlite3, yfinance as yf
+c = sqlite3.connect('family_office.db')
+for s in ['PLTR','VOO']:
+    p = c.execute('SELECT price FROM positions WHERE symbol=?', (s,)).fetchone()[0]
+    live = yf.download(s, period='2d', progress=False)['Close'].iloc[-1]
+    print(f'{s}: DB {p:.2f} vs live close {float(live):.2f}')
+"
+```
+
 ## Layer Classification for New Tickers
 
 Dividend funds → Layer 2, growth → Layer 1, hedges → Layer 3. If a new ticker does not clearly match a pattern, mark it `UNKNOWN - Manual Review Required` and ask the user rather than guessing.

--- a/.claude/skills/TransactionSyncing/CategoryRules.md
+++ b/.claude/skills/TransactionSyncing/CategoryRules.md
@@ -408,3 +408,63 @@ When the user wants to add new categories or patterns:
 
 **Last Updated**: 2026-01-02
 **Maintainer**: Finance Guru TransactionSyncing skill
+
+---
+
+## Ordering rules (2026-08-04)
+
+`CATEGORY_PATTERNS` is an ordered dict and **the first match wins**, so placement
+is behavior, not style. Three orderings are load-bearing:
+
+1. **Travel before Credit Card Payment** so "American Express Travel" is a trip,
+   not a card payment.
+2. **Credit Card Payment before Bills & Utilities.** A card autopay memo reads
+   "Chase Credit Cautopay", which contains the substring `autopay`. With Bills &
+   Utilities first, every card payment was mis-filed as a utility bill.
+3. **`credit card payment` belongs to Credit Card Payment, not Loan Payment.**
+   It used to sit in Loan Payment, which is matched earlier, so card payments
+   never reached their own category.
+
+## Match against payee AND description
+
+The sync joins both fields before categorizing. `description` is the raw bank
+memo (`DIRECT DEBIT AMEX EPAYMENT ACH PMT`); `payee` is SimpleFIN's normalized
+merchant name (`American Express Credit Card`). Matching description alone left
+67% of debit volume Uncategorized. **When adding a pattern, cover the
+abbreviated memo form too**, for example `vehreg` alongside
+`vehicle registration`, and `amex epayment` alongside `amex payment`.
+
+## Non-spend categories
+
+`NON_SPEND_CATEGORIES` in `categorize.py` holds `Transfer`,
+`Credit Card Payment`, `Crypto Deposit`, and `Exempt`. These move money rather
+than consume it and **must be excluded from spend totals**. Including them
+double-counts: once when a purchase hits the card, again when the card bill is
+paid. On 2026-08-04 that inflated a 30-day review from a real $10,991 to a
+reported $31,304.
+
+## Categories added 2026-08-04
+
+### Giving
+Church and ministry contributions.
+
+**Patterns**: `anglicanchurch`, `church`, `tithe`, `offering`, `ministry`, `missions`
+
+### Fees & Interest
+Card interest and bank charges, kept out of merchant spend.
+
+**Patterns**: `interest charge`, `finance charge`, `annual fee`, `late fee`, `overdraft`, `service charge`, `maintenance fee`
+
+### Additions to existing categories
+
+- **Transfer**: `transferred to`, `transfer to`, `transfer withdrawal`, `webxtransfer`, `wire transfer`
+- **Credit Card Payment**: `credit card payment`, `american express credit card`, `chase credit ca`, `wf credit card`, `apple credit card`, `amex epayment`, `credit card`
+- **Loan Payment**: `mortg`, `mtgpmt`, `aes stdnt` (bank memos abbreviate)
+- **Auto & Transport**: `vehicle registration`, `vehreg`, `dmv`
+- **Business Expense**: `anthropic`, `claude.ai`, `cursor`, `github`, `vercel`
+
+## Deliberately left Uncategorized
+
+`Paid Check` and `Target` are ambiguous by nature: a written check or a Target
+run can be groceries, household, or shopping. Guessing is worse than a visible
+gap. Review these by hand.

--- a/.claude/skills/TransactionSyncing/SKILL.md
+++ b/.claude/skills/TransactionSyncing/SKILL.md
@@ -20,11 +20,112 @@ uv run python -m src.integrations.simplefin.sync_expenses_db --months 3   # card
 uv run python -m src.integrations.refresh_all --months 3
 ```
 
-Completion criterion: _the `transactions` and `bank_transactions` tables carry this run's `synced_at`._
+Completion criterion: _both sync commands report success._ Do not gate on
+`MAX(synced_at)` advancing: both layers are idempotent and only stamp rows they
+actually write, so a run with no new activity leaves the timestamp untouched.
+Read the command output instead (`N inserted, M updated, K skipped`).
+
+## ⚠️ The two feeds do not run at the same speed
+
+**`bank_transactions` (SimpleFIN) is current. `transactions` (SnapTrade) lags by
+days.** Verified 2026-08-04: the `positions` table showed PLTR and TSLA puts
+opened on 2026-08-03, while `transactions` had no row for either buy and its
+latest activity date was still 2026-07-31. SnapTrade updated holdings before it
+published the activity that created them.
+
+**Consequence: never conclude "X did not happen" from an absence in
+`transactions`.** A missing row means "not published yet" at least as often as it
+means "did not occur". To answer whether something executed:
+
+1. Check `positions` for a holdings change (fastest signal).
+2. Check `bank_transactions` for the cash leg, which is current.
+3. Only then read `transactions`, and treat the tail few days as incomplete.
+
+The same applies to month-boundary reporting: the last several days of any period
+may still be missing from the investment side.
 
 ## Direction and sign
 
 `bank_transactions.direction` is resolved by `resolve_direction()` in `src/integrations/simplefin/sync_expenses_db.py`. Explicit feed wording wins over amount sign, because Fidelity's CMA reports inbound payroll with the same negative sign it uses for outflows. `amount` is signed to match direction, so `SUM(amount)` is real cash flow: credits positive, debits negative.
+
+## ⚠️ Household spending lives in THREE streams, in two different tables
+
+**A spending review that reads only `bank_transactions` is wrong.** Measured for
+July 2026: that table showed $7,936 of personal spend. The true figure was
+**$13,500**. The missing 41% was in the other two streams.
+
+| Stream | Table | July 2026 |
+|---|---|---|
+| 1. Bank and card accounts (SimpleFIN) | `bank_transactions` | $7,936.23 |
+| 2. **Brokerage direct debits (SnapTrade)** | **`transactions`** | **$4,814.80** |
+| 3. Cards paid but not connected | neither, infer from the bill | $748.69 |
+
+Stream 2 is the one that gets forgotten. The Fidelity brokerage pays the
+mortgage, insurance, utilities, phone, tuition, and has a debit card used for
+groceries. Those rows are `type='WITHDRAWAL'` in `transactions`, not in
+`bank_transactions` at all.
+
+```bash
+sqlite3 family_office.db \
+  "SELECT date, description, -amount FROM transactions
+   WHERE type = 'WITHDRAWAL' AND date LIKE '2026-07%' ORDER BY -amount DESC;"
+```
+
+Categorize those rows with the same `categorize_expense()`, then separate:
+
+- **Household consumption**: mortgage, insurance, groceries, utilities, tuition.
+- **Not consumption**: `MARGIN INTEREST` (financing cost, report separately),
+  card bill payments, and `JOURNALED` internal moves.
+
+**Check for double counting across the two tables** by matching amount and date
+within a couple of days. In July exactly one pair collided ($50 on 7/24) and
+inspection showed two genuinely separate payments, not a duplicate. Inspect; do
+not assume either way.
+
+**Income totals have the mirror-image problem.** Credits into
+`bank_transactions` include transfers between the principal's own accounts, so
+summing them overstates income. Net internal movement out before quoting a
+surplus.
+
+## Spending reviews: count purchases, exclude bill payments, then AUDIT COVERAGE
+
+**Count card purchases. Exclude card bill payments.** Both are debits, but a
+purchase and the payment of that same purchase are one dollar of spending, not
+two. Exclude the categories in `NON_SPEND_CATEGORIES`, and exclude
+`BUSINESS_CATEGORIES` plus the business accounts when the question is household
+spending.
+
+**That exclusion is only valid if every card that receives a payment also
+reports its purchases.** When a card is paid but not connected, its purchases are
+invisible and its payment was excluded, so the spending vanishes entirely. Run
+this before quoting any total:
+
+```bash
+uv run python -c "
+import sqlite3
+c = sqlite3.connect('family_office.db')
+print('Cards receiving payments:')
+for r in c.execute(\"SELECT DISTINCT COALESCE(payee,description) FROM bank_transactions WHERE category='Credit Card Payment'\"):
+    print('  ', r[0])
+print('Card accounts reporting purchases (with last activity):')
+for r in c.execute(\"SELECT account_name, MAX(date), COUNT(*) FROM bank_transactions WHERE LOWER(COALESCE(org,'')) LIKE '%credit%' OR LOWER(COALESCE(org,'')) LIKE '%express%' GROUP BY account_id\"):
+    print(f'   {r[0]:<38} last {r[1]}  ({r[2]} rows)')
+"
+```
+
+Two failure modes, both found 2026-08-04:
+
+1. **Paid but not connected.** An Apple Card bill of $748.69 cleared on
+   2026-08-03 with zero Apple purchases anywhere in the feed. That understated
+   July household spending by roughly 8%. **Backfill from the bill amount and say
+   so**, or connect the account.
+2. **Connected but stale.** Chase Sapphire Preferred stopped reporting on
+   2026-07-17 and an older card had produced nothing since 2026-04-21. A stale
+   connection looks identical to genuinely low spending. Treat any card whose
+   last activity is more than about a week old as suspect.
+
+**Always state the coverage caveat alongside the total.** A household number
+carrying an unquantified gap is worse than one carrying a stated one.
 
 ## Workflow Routing
 
@@ -195,7 +296,11 @@ Uncategorized rows are the follow-up: add the pattern to
 ## Pre-Flight Checklist
 
 Before syncing transactions:
-- [ ] `DATABASE_URL` and `SIMPLEFIN_ACCESS_URL` are set in `.env`
+- [ ] `DATABASE_URL` is set in the project-root `.env`
+- [ ] `SIMPLEFIN_ACCESS_URL` is set in **`apps/simplefin-sync/.env`**, not the
+      project root. The expense adapter shells out to `bun run src/dump.ts` inside
+      that workspace, so the token is read by the Bun app from its own `.env`.
+      Checking the root `.env` for it produces a false "MISSING" (hit 2026-08-04).
 - [ ] SnapTrade account is enabled and routed in `config/snaptrade-accounts.yaml`
 - [ ] Current date retrieved via `date` command
 

--- a/.claude/skills/dividend-tracking/SKILL.md
+++ b/.claude/skills/dividend-tracking/SKILL.md
@@ -20,7 +20,27 @@ uv run python -m src.integrations.snaptrade.sync_transactions_db          # writ
 uv run python -m src.integrations.snaptrade.sync_transactions_db --show   # confirm freshness
 ```
 
-Completion criterion: _the `transactions` table carries this run's `synced_at` before any dividend is read._
+Completion criterion: _the sync command reports success before any dividend is read._
+
+**Do not gate on `MAX(synced_at)` advancing.** The activities sync is idempotent
+via `dedupe_key` and only stamps rows it actually writes, so a run that finds no
+new activity leaves the timestamp untouched. Verified 2026-08-04: the sync
+reported `2690 fetched, 0 new, 2690 duplicates skipped` and `MAX(synced_at)`
+stayed at the prior run's value. That is a healthy no-op, not a stale table.
+
+Read the command's own output line instead:
+
+- `N new` greater than 0, timestamp advances → new activity ingested.
+- `0 new, N duplicates skipped` → already complete, timestamp correctly unchanged.
+- Command errors or reports nothing → genuine failure, stop.
+
+Completeness is guaranteed by the dedupe key, not by the stamp.
+
+**Month-end lag:** distributions post over several days, so the current month is
+incomplete until roughly the 3rd or 4th of the following month. On 2026-07-31,
+July read $1,346 across 30 payments; the month actually closed at **$1,570 across
+42**. Never compare a partial current month against completed prior months, and
+never call a month-over-month decline until the month has closed.
 
 ## Reading dividends
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restored the Travel and Transfer categories in transaction categorization,
   and unpinned the affected test from a private script (#114).
+- SimpleFIN expense categorization now matches on the normalized `payee` as
+  well as the raw `description`, which had left 67% of 30-day debit volume
+  uncategorized, and credit card payments no longer fall through to
+  `Loan Payment`.
+- Transaction direction no longer trusts the Fidelity CMA amount sign, which is
+  wrong in both directions; debit-card purchases, cash advances, and the two
+  legs of an internal transfer are now resolved from the feed wording.
+
+### Security
+
+- Scrubbed PII from HEAD and stopped the compliance scanner passing blind
+  (#123), and untracked the QA PII replacement files (#122).
+- Business-account detection no longer hard-codes entity names in source; extra
+  hints are supplied at runtime through `FG_BUSINESS_ACCOUNT_HINTS`.
 
 ## [2.2.0] - 2026-07-27
 

--- a/src/integrations/simplefin/categorize.py
+++ b/src/integrations/simplefin/categorize.py
@@ -1,5 +1,7 @@
 """Categorize SimpleFIN transactions using ordered merchant patterns."""
 
+import os
+
 # Order matters: the first matching category wins. Transfer and Travel come
 # first so an explicit remittance is not read as a merchant, and so
 # "American Express Travel" lands in Travel rather than Credit Card Payment.
@@ -11,6 +13,13 @@ CATEGORY_PATTERNS: dict[str, tuple[str, ...]] = {
         "zelle",
         "venmo",
         "cash app",
+        # Moving money between own accounts is not spending. Keeping these out of
+        # Uncategorized stops them inflating the expense review.
+        "transferred to",
+        "transfer to",
+        "transfer withdrawal",
+        "webxtransfer",
+        "wire transfer",
     ),
     "Travel": (
         "american express travel",
@@ -61,9 +70,37 @@ CATEGORY_PATTERNS: dict[str, tuple[str, ...]] = {
         "makiin",
         "sparkly photo",
     ),
+    # Must precede Bills & Utilities: a card autopay string such as
+    # "Chase Credit Cautopay" contains "autopay" and would otherwise be read as a
+    # utility bill. Must follow Travel so "American Express Travel" stays Travel.
+    "Credit Card Payment": (
+        "applecard",
+        "gsbapayment",
+        "chase payment",
+        "amex payment",
+        "discover payment",
+        "credit card payment",
+        "american express credit card",
+        "chase credit ca",
+        "wf credit card",
+        "apple credit card",
+        "amex epayment",  # raw bank memo form: "DIRECT DEBIT AMEX EPAYMENT ACH PMT"
+        "credit card",
+    ),
+    "Giving": (
+        "anglicanchurch",
+        "church",
+        "tithe",
+        "offering",
+        "ministry",
+        "missions",
+    ),
     "Auto & Transport": (
         "tesla",
         "supercha",
+        "vehicle registration",
+        "vehreg",
+        "dmv",
         "parking",
         "fastpark",
         "uber",
@@ -159,13 +196,36 @@ CATEGORY_PATTERNS: dict[str, tuple[str, ...]] = {
         "zoom",
         "openai",
         "chatgpt",
+        "anthropic",
+        "claude.ai",
+        "cursor",
+        "github",
+        "vercel",
     ),
+    # "credit card payment" deliberately NOT listed here: it belongs to the
+    # dedicated Credit Card Payment category below. Leaving it in Loan Payment
+    # (which is matched first) sent card payments to the wrong bucket.
     "Loan Payment": (
         "loan payment",
         "mortgage",
+        "mortg",  # Fidelity/Truist abbreviate: "TRUIST MORTG TEL MTGPMT"
+        "mtgpmt",
         "car payment",
         "student loan",
-        "credit card payment",
+        "aes stdnt",
+    ),
+    "Fees & Interest": (
+        "interest charge",
+        "finance charge",
+        "annual fee",
+        "annual membership fee",
+        "membership fee",
+        "late fee",
+        "overdraft",
+        "service charge",
+        "maintenance fee",
+        "maintenance charge",
+        "sie fee",
     ),
     "Home & Garden": (
         "home depot",
@@ -183,24 +243,94 @@ CATEGORY_PATTERNS: dict[str, tuple[str, ...]] = {
         "eth deposited",
         "crypto",
     ),
-    "Credit Card Payment": (
-        "applecard",
-        "gsbapayment",
-        "chase payment",
-        "amex payment",
-        "discover payment",
-    ),
 }
+
+# Categories that move money rather than consume it. Expense reviews should
+# exclude these from spend totals, otherwise a card purchase is counted twice:
+# once on the card account and again when the card bill is paid.
+NON_SPEND_CATEGORIES: frozenset[str] = frozenset(
+    {"Transfer", "Credit Card Payment", "Crypto Deposit", "Exempt", "Retirement"}
+)
+
+# Categories belonging to a business entity rather than the household.
+# Personal-spending reviews exclude these; business P&L includes them.
+BUSINESS_CATEGORIES: frozenset[str] = frozenset({"Payroll", "Business Expense"})
+
+# Substrings identifying a business bank account by name. A written check means
+# different things by account: employee payroll on a business account, unknown
+# personal spending on a household one. Text alone cannot tell them apart.
+# Only generic, non-identifying substrings live here. Entity names are private
+# data, so extra hints are supplied at runtime via FG_BUSINESS_ACCOUNT_HINTS
+# (comma-separated) rather than committed to the repo.
+BUSINESS_ACCOUNT_HINTS: tuple[str, ...] = (
+    "business",
+    "llc",
+)
+
+_BUSINESS_HINT_ENV = "FG_BUSINESS_ACCOUNT_HINTS"
+
+
+def _extra_business_hints() -> tuple[str, ...]:
+    """Return operator-supplied business-account hints from the environment."""
+    raw = os.environ.get(_BUSINESS_HINT_ENV, "")
+    return tuple(hint.strip().lower() for hint in raw.split(",") if hint.strip())
+
+
+# Substrings identifying a retirement account by name. Contributions and
+# in-plan dividends are savings, not household consumption, and the account name
+# is the only reliable signal: the feed's bare "contribution" memo is too generic
+# to match on, since a charitable contribution is real spending.
+RETIREMENT_ACCOUNT_HINTS: tuple[str, ...] = ("401(k)", "401k", "retirement")
+
+# Check-writing patterns. Only classified as Payroll on a business account.
+_CHECK_PATTERNS: tuple[str, ...] = ("paid check", "cashed check", "check paid")
+
+_PAYROLL_PATTERNS: tuple[str, ...] = (
+    "payroll",
+    "gusto",
+    "adp ",
+    "paychex",
+    "direct deposit to employee",
+    # Employers vary the memo suffix ("...PAYROLL", "...DIR DEP", "...ACH"), so
+    # matching the suffix misses payers. An inbound direct deposit is income by
+    # definition; sub-dollar bank verification deposits are already returned
+    # Exempt by the amount rule above, before this table is reached.
+    "direct deposit",
+)
+
+
+def is_business_account(account_name: str | None) -> bool:
+    """Return True when the account belongs to a business entity.
+
+    Matches the generic hints plus any supplied via ``FG_BUSINESS_ACCOUNT_HINTS``.
+    """
+    normalized = (account_name or "").lower()
+    hints = BUSINESS_ACCOUNT_HINTS + _extra_business_hints()
+    return any(hint in normalized for hint in hints)
+
+
+def is_retirement_account(account_name: str | None) -> bool:
+    """Return True when the account is a retirement plan."""
+    normalized = (account_name or "").lower()
+    return any(hint in normalized for hint in RETIREMENT_ACCOUNT_HINTS)
+
 
 # "target" and "school" are deliberately omitted because their categories are ambiguous.
 
 
-def categorize_expense(text: str | None, amount: float | None = None) -> str:
+def categorize_expense(
+    text: str | None,
+    amount: float | None = None,
+    account_name: str | None = None,
+) -> str:
     """Return the first matching expense category.
 
     Args:
-        text: Transaction description or payee text.
+        text: Transaction payee and description text, joined.
         amount: Parsed transaction amount, when available.
+        account_name: Owning account name. Required to distinguish business
+            payroll from personal spending, because identical memo text
+            ("Paid Check") means different things by account.
 
     Returns:
         The matching category, ``Exempt``, or ``Uncategorized``.
@@ -211,6 +341,21 @@ def categorize_expense(text: str | None, amount: float | None = None) -> str:
     normalized = (text or "").lower()
     if "ifacctverify" in normalized or "verification" in normalized:
         return "Exempt"
+
+    # Everything on a retirement account is savings or in-plan activity, never
+    # household consumption, so the account decides before any text pattern runs.
+    if is_retirement_account(account_name):
+        return "Retirement"
+
+    # Account-aware rules run before the text table: a check drawn on a business
+    # account is employee payroll, which the generic patterns would read as a
+    # Transfer and silently drop from the business P&L.
+    if any(pattern in normalized for pattern in _PAYROLL_PATTERNS):
+        return "Payroll"
+    if is_business_account(account_name) and any(
+        pattern in normalized for pattern in _CHECK_PATTERNS
+    ):
+        return "Payroll"
 
     for category, patterns in CATEGORY_PATTERNS.items():
         if any(pattern in normalized for pattern in patterns):

--- a/src/integrations/simplefin/sync_expenses_db.py
+++ b/src/integrations/simplefin/sync_expenses_db.py
@@ -123,16 +123,27 @@ def _iso_date(posted_ts: Any) -> str | None:
     return datetime.fromtimestamp(timestamp, UTC).date().isoformat()
 
 
-_WITHDRAWAL_MARKERS = ("direct debit",)
-_DEPOSIT_MARKERS = ("direct deposit", "direct dep")
+_WITHDRAWAL_MARKERS = (
+    "direct debit",
+    "debit card purchase",
+    "cash advance",
+    "transferred to",
+)
+_DEPOSIT_MARKERS = ("direct deposit", "direct dep", "transferred from")
 
 
 def resolve_direction(text: str | None, amount: float | None) -> str:
     """Resolve credit/debit, preferring explicit feed wording over amount sign.
 
-    Fidelity's CMA feed reports inbound payroll with the same negative sign it
-    uses for outflows, so sign alone books every direct deposit as spending.
+    Fidelity's sign is unreliable in BOTH directions, so sign alone is not
+    trustworthy for that feed: inbound payroll arrives negative, while debit-card
+    purchases and cash advances arrive positive. Verified 2026-08-31 against the
+    authoritative SnapTrade ``transactions`` rows for the same transactions.
     Explicit wording wins; sign remains the fallback for feeds that get it right.
+
+    Note ``transferred to`` (outflow) and ``transferred from`` (inflow) are both
+    listed: the two legs of an internal Fidelity transfer share an amount sign,
+    so only the wording distinguishes them.
 
     Args:
         text: Transaction description or payee text, may be None.
@@ -170,6 +181,14 @@ def normalize_transaction(
         posted_ts = None
     amount = _to_float(txn.get("amount"))
     text = txn.get("description") or txn.get("payee")
+    # Categorize against BOTH fields. `description` is the raw bank memo
+    # ("DIRECT DEBIT AMEX EPAYMENT ACH PMT"), while `payee` is SimpleFIN's
+    # normalized merchant name ("American Express Credit Card"). Matching only
+    # description missed every payee-shaped pattern and left 67% of debit volume
+    # Uncategorized (found 2026-08-04).
+    category_text = " ".join(
+        part for part in (txn.get("payee"), txn.get("description")) if part
+    )
     direction = resolve_direction(text, amount)
     # Keep sign consistent with direction so SUM(amount) reflects real cash flow.
     if amount is not None:
@@ -185,7 +204,7 @@ def normalize_transaction(
         txn.get("description"),
         amount,
         direction,
-        categorize_expense(text, amount),
+        categorize_expense(category_text, amount, account.get("name")),
         now,
     )
 

--- a/tests/python/test_categorize.py
+++ b/tests/python/test_categorize.py
@@ -1,0 +1,262 @@
+"""Tests for SimpleFIN expense categorization.
+
+Covers the patterns added 2026-08-04 after a spending review found 72% of
+30-day debit volume landing in Uncategorized, and the ordering bug that sent
+credit card payments to Loan Payment.
+"""
+
+import pytest
+
+from src.integrations.simplefin.categorize import (
+    BUSINESS_CATEGORIES,
+    NON_SPEND_CATEGORIES,
+    categorize_expense,
+    is_business_account,
+)
+
+
+class TestBusinessPayroll:
+    """A written check means employee payroll on a business account and
+    something unknown on a household one. Confirmed by the account owner
+    2026-08-04: the two $2,400 checks on Business Basic Checking (5468) are
+    employee payroll, and were landing in Transfer and Uncategorized."""
+
+    BIZ = "Business Basic Checking (5468)"
+    PERSONAL = "360 Checking (6851)"
+
+    @pytest.mark.parametrize("memo", ["Paid Check", "Cashed Check", "Check paid"])
+    def test_check_on_business_account_is_payroll(self, memo: str) -> None:
+        assert categorize_expense(memo, -2400.00, self.BIZ) == "Payroll"
+
+    @pytest.mark.parametrize("memo", ["Paid Check", "Cashed Check"])
+    def test_check_on_personal_account_is_not_payroll(self, memo: str) -> None:
+        assert categorize_expense(memo, -2400.00, self.PERSONAL) != "Payroll"
+
+    def test_missing_account_never_guesses_payroll(self) -> None:
+        assert categorize_expense("Paid Check", -2400.00, None) != "Payroll"
+
+    @pytest.mark.parametrize(
+        "memo", ["Gusto payroll", "ADP Payroll Fees", "Paychex", "payroll run"]
+    )
+    def test_explicit_payroll_needs_no_account(self, memo: str) -> None:
+        assert categorize_expense(memo, -2400.00, None) == "Payroll"
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("Business Basic Checking (5468)", True),
+            ("Example Consulting Group LLC", True),
+            ("Placeholder LLC Operating", True),
+            ("360 Checking (6851)", False),
+            ("Platinum Card® (1006)", False),
+            (None, False),
+        ],
+    )
+    def test_business_account_detection(self, name: str | None, expected: bool) -> None:
+        assert is_business_account(name) is expected
+
+    def test_env_hints_extend_business_detection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Entity names are private, so operators add them via the environment.
+
+        Without the env hint the account reads as personal, and a check on it is
+        not payroll; with it, the same account and memo resolve to Payroll.
+        """
+        account = "Northwind Operating"
+        assert is_business_account(account) is False
+        assert categorize_expense("Paid Check", -2400.00, account) != "Payroll"
+
+        monkeypatch.setenv("FG_BUSINESS_ACCOUNT_HINTS", "northwind, acme")
+        assert is_business_account(account) is True
+        assert is_business_account("ACME Holdings") is True
+        assert categorize_expense("Paid Check", -2400.00, account) == "Payroll"
+
+    def test_blank_env_hints_do_not_match_everything(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty or whitespace-only setting must not turn every account business."""
+        monkeypatch.setenv("FG_BUSINESS_ACCOUNT_HINTS", " , ,")
+        assert is_business_account("360 Checking (6851)") is False
+
+    def test_payroll_is_a_business_category(self) -> None:
+        assert "Payroll" in BUSINESS_CATEGORIES
+        assert "Groceries" not in BUSINESS_CATEGORIES
+
+
+class TestCardFees:
+    """Annual card fees were falling through to Uncategorized."""
+
+    @pytest.mark.parametrize(
+        "memo",
+        [
+            "Membership Fee",
+            "Annual Membership Fee",
+            "Maintenance Charge",
+            "Overdraft Charge",
+            "Late Fee",
+            "Interest Charge",
+        ],
+    )
+    def test_fees_are_categorized(self, memo: str) -> None:
+        assert categorize_expense(memo, -895.00) == "Fees & Interest"
+
+
+class TestExemptions:
+    """Sub-dollar and verification rows never reach the pattern table."""
+
+    @pytest.mark.parametrize("amount", [0.0, 0.45, -0.99])
+    def test_sub_dollar_amounts_are_exempt(self, amount: float) -> None:
+        assert categorize_expense("H-E-B Curbside", amount) == "Exempt"
+
+    @pytest.mark.parametrize(
+        "text",
+        ["Direct Debit Wells Fargo Ifacctverify", "micro verification deposit"],
+    )
+    def test_verification_rows_are_exempt(self, text: str) -> None:
+        assert categorize_expense(text, -50.00) == "Exempt"
+
+    def test_none_text_is_uncategorized(self) -> None:
+        assert categorize_expense(None, -50.00) == "Uncategorized"
+
+
+class TestTransfers:
+    """Regression: own-account movement was inflating the expense review."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Transferred to Z Cash",
+            "Transfer to brokerage",
+            "DIRECT DEBIT BMOBNK CK WEBXTRANSFER",
+            "Outgoing wire transfer",
+        ],
+    )
+    def test_account_movement_is_a_transfer(self, text: str) -> None:
+        assert categorize_expense(text, -900.00) == "Transfer"
+
+    def test_taptap_send_still_matches(self) -> None:
+        assert categorize_expense("TapTap Send US", -800.00) == "Transfer"
+
+
+class TestCreditCardPayments:
+    """Regression: 'credit card payment' lived in Loan Payment, which is
+    matched first, so card payments were bucketed as loan repayment."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "American Express Credit Card",
+            "Direct Debit Chase Credit Cautopay Cash",
+            "Apple Credit Card",
+            "WF Credit Card auto pay",
+            "Credit card payment",
+        ],
+    )
+    def test_card_payments_are_credit_card_payment(self, text: str) -> None:
+        assert categorize_expense(text, -9402.47) == "Credit Card Payment"
+
+    def test_real_loans_still_route_to_loan_payment(self) -> None:
+        assert categorize_expense("DIRECT DEBIT AES STDNT LOAN", -4169.25) == (
+            "Loan Payment"
+        )
+        assert categorize_expense("TRUIST MORTG TEL MTGPMT", -1500.00) == (
+            "Loan Payment"
+        )
+
+    def test_amex_travel_still_beats_card_payment(self) -> None:
+        """Travel is matched before Credit Card Payment on purpose."""
+        assert categorize_expense("American Express Travel", -813.44) == "Travel"
+
+
+class TestNewCategories:
+    def test_church_giving(self) -> None:
+        assert categorize_expense("Anglicanchurchofpentx", -100.00) == "Giving"
+
+    def test_interest_charge_is_a_fee(self) -> None:
+        assert categorize_expense("Interest Charge", -267.86) == "Fees & Interest"
+
+    def test_vehicle_registration_is_transport(self) -> None:
+        assert (
+            categorize_expense("State of Texas Vehicle Registration", -272.00)
+            == "Auto & Transport"
+        )
+
+    def test_ai_tooling_is_a_business_expense(self) -> None:
+        assert categorize_expense("Anthropic", -210.80) == "Business Expense"
+
+
+class TestRawBankMemos:
+    """The sync feeds payee + description joined. Raw bank memos are terse and
+    abbreviated, so patterns must match those forms too, not just the clean
+    payee name. Every case below is a real row that stayed Uncategorized until
+    2026-08-04."""
+
+    @pytest.mark.parametrize(
+        ("payee", "description", "expected"),
+        [
+            (
+                "American Express Credit Card",
+                "DIRECT DEBIT AMEX EPAYMENT ACH PMT (Cash)",
+                "Credit Card Payment",
+            ),
+            ("Transfer", "TRANSFER WITHDRAWAL To ....6851", "Transfer"),
+            (
+                "State of Texas Vehicle Registration",
+                "BRAZORIA VEHREG 1302ANGLETON TX",
+                "Auto & Transport",
+            ),
+        ],
+    )
+    def test_joined_payee_and_description(
+        self, payee: str, description: str, expected: str
+    ) -> None:
+        assert categorize_expense(f"{payee} {description}", -500.00) == expected
+
+    def test_raw_memo_alone_still_matches(self) -> None:
+        """Even without the payee, the abbreviated memo must categorize."""
+        assert categorize_expense("DIRECT DEBIT AMEX EPAYMENT ACH PMT", -9402.47) == (
+            "Credit Card Payment"
+        )
+        assert categorize_expense("BRAZORIA VEHREG 1302ANGLETON TX", -272.00) == (
+            "Auto & Transport"
+        )
+
+
+class TestNonSpendSet:
+    """Expense totals must be able to exclude money movement."""
+
+    def test_membership(self) -> None:
+        assert "Transfer" in NON_SPEND_CATEGORIES
+        assert "Credit Card Payment" in NON_SPEND_CATEGORIES
+        assert "Groceries" not in NON_SPEND_CATEGORIES
+
+    def test_double_count_case_is_excluded(self) -> None:
+        """An Amex purchase and the Amex bill payment must not both count."""
+        purchase = categorize_expense("Amazon", -329.83)
+        bill = categorize_expense("American Express Credit Card", -9402.47)
+        assert purchase not in NON_SPEND_CATEGORIES
+        assert bill in NON_SPEND_CATEGORIES
+
+
+class TestUnchangedBehaviour:
+    """Existing patterns must keep working."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("H-E-B CURBSIDE", "Groceries"),
+            ("Starbucks", "Dining Out"),
+            ("Tesla Supercharger", "Auto & Transport"),
+            ("CVS Pharmacy", "Health & Wellness"),
+            ("Amazon", "Shopping"),
+            ("Brightwheel", "Family Care"),
+            ("Netflix subscription", "Bills & Utilities"),
+            ("ATM cash withdrawal", "Cash Withdrawal"),
+        ],
+    )
+    def test_known_merchants(self, text: str, expected: str) -> None:
+        assert categorize_expense(text, -50.00) == expected
+
+    def test_unknown_merchant_stays_uncategorized(self) -> None:
+        assert categorize_expense("Zzyzx Novelty Co", -50.00) == "Uncategorized"

--- a/tests/python/test_simplefin_expenses.py
+++ b/tests/python/test_simplefin_expenses.py
@@ -1,7 +1,10 @@
 import sqlite3
 from copy import deepcopy
 
-from src.integrations.simplefin.categorize import categorize_expense
+from src.integrations.simplefin.categorize import (
+    NON_SPEND_CATEGORIES,
+    categorize_expense,
+)
 from src.integrations.simplefin.sync_expenses_db import (
     normalize_transaction,
     resolve_direction,
@@ -128,3 +131,96 @@ def test_sync_inserts_updates_and_promotes_pending_transaction(tmp_path) -> None
         count = conn.execute("SELECT COUNT(*) FROM bank_transactions").fetchone()[0]
     assert pending_date == "2024-01-02"
     assert count == 2
+
+
+def test_resolve_direction_handles_fidelity_card_and_transfer_wording() -> None:
+    """Fidelity's sign is unreliable in BOTH directions, so wording must win.
+
+    Every case below is a real row from the Fidelity brokerage feed whose
+    SimpleFIN sign contradicts the authoritative SnapTrade `transactions` row
+    for the same transaction (verified 2026-08-31).
+    """
+    # Outflows the feed reported as positive.
+    assert (
+        resolve_direction(
+            "CASH ADVANCE *SEDONA LAKES MANVEL TX 081826 AUTHID:624330 (Cash)", 654.00
+        )
+        == "debit"
+    )
+    assert (
+        resolve_direction(
+            "DEBIT CARD PURCHASE GUMROAD* SHAWN GRADY GUMROAD.COM NY 082226", 21.60
+        )
+        == "debit"
+    )
+    assert (
+        resolve_direction(
+            "DEBIT CARD PURCHASE CASH APP*ANGLICAN CHUR cash.app TX 082726", 20.00
+        )
+        == "debit"
+    )
+    # An inflow the feed reported as negative: SnapTrade books it CONTRIBUTION +650.
+    assert (
+        resolve_direction("TRANSFERRED FROM VS ZXX-XXX752-1 (Cash)", -650.00)
+        == "credit"
+    )
+    # The outbound leg on the CMA side stays an outflow.
+    assert (
+        resolve_direction("TRANSFERRED TO VS ZXX-XXX592-1 (Cash)", -650.00) == "debit"
+    )
+    # "direct debit" must still win over the newer, less specific markers.
+    assert (
+        resolve_direction("DIRECT DEBIT CHASE CREDIT CAUTOPAYBUS (Cash)", -477.33)
+        == "debit"
+    )
+
+
+def test_retirement_account_activity_is_not_household_spending() -> None:
+    """401(k) contributions are savings, not consumption.
+
+    The 401(k) feed reports biweekly contributions as debits with the bare
+    memo "contribution", which the text table reads as Uncategorized and books
+    as household spend. Verified 2026-08-31: $307.70 of phantom August spend.
+    The account name is the only reliable signal, since "contribution" alone is
+    too generic to match on (a charitable contribution is real spending).
+    """
+    retirement = "EXAMPLE EMPLOYER 401(K) RETIREMENT PLAN"
+    assert categorize_expense("contribution", -123.08, retirement) == "Retirement"
+    assert categorize_expense("contribution", -30.77, retirement) == "Retirement"
+    assert categorize_expense("dividend", 7.84, retirement) == "Retirement"
+    # Retirement must be excluded from household spending totals.
+    assert "Retirement" in NON_SPEND_CATEGORIES
+    # A contribution on a normal account is still ordinary spending, not Retirement.
+    assert (
+        categorize_expense("CONTRIBUTION TO CHURCH", -100.00, "Platinum Card® (1006)")
+        != "Retirement"
+    )
+
+
+def test_inbound_direct_deposits_are_payroll_regardless_of_employer_memo() -> None:
+    """Employers vary the memo suffix; the deposit is payroll either way.
+
+    Verified 2026-08-31: Christian Brothers, Goucher and one Actalent variant say
+    "PAYROLL" and tagged correctly, while APEX Systems ("DIR DEP") and Actalent's
+    "ACH" variant fell through to Uncategorized, leaving $41,763.89 of income
+    untagged. The verification micro-deposits must stay Exempt.
+    """
+    cma = "Cash Management (Joint WROS) (4752)"
+    assert (
+        categorize_expense("DIRECT DEPOSIT APEX SYSTEMSDIR DEP (Cash)", 2207.38, cma)
+        == "Payroll"
+    )
+    assert (
+        categorize_expense("DIRECT DEPOSIT Actalent SerACH (Cash)", 2273.03, cma)
+        == "Payroll"
+    )
+    # Already-working variants must not regress.
+    assert (
+        categorize_expense("DIRECT DEPOSIT GOUCHER COLLPAYROLL (Cash)", 2431.51, cma)
+        == "Payroll"
+    )
+    # Sub-dollar bank verification deposits stay Exempt, not payroll.
+    assert (
+        categorize_expense("DIRECT DEPOSIT WELLS FARGO ACCTVERIFY", 0.29, cma)
+        == "Exempt"
+    )

--- a/tests/python/test_simplefin_expenses.py
+++ b/tests/python/test_simplefin_expenses.py
@@ -54,11 +54,11 @@ def test_categorize_expense_patterns_and_exemptions() -> None:
 def test_resolve_direction_prefers_feed_wording_over_sign() -> None:
     # Fidelity's CMA reports inbound payroll negative; wording must win.
     assert (
-        resolve_direction("DIRECT DEPOSIT APEX SYSTEMSDIR DEP (Cash)", -1428.61)
+        resolve_direction("DIRECT DEPOSIT ACME STAFFINGDIR DEP (Cash)", -1428.61)
         == "credit"
     )
     assert (
-        resolve_direction("DIRECT DEPOSIT Actalent SerPAYROLL (Cash)", -2273.03)
+        resolve_direction("DIRECT DEPOSIT Ridgeline SerPAYROLL (Cash)", -2273.03)
         == "credit"
     )
     assert (
@@ -79,7 +79,7 @@ def test_normalize_transaction_signs_amount_to_match_direction() -> None:
         "id": "TXN-payroll",
         "posted": 1704067200,
         "payee": None,
-        "description": "DIRECT DEPOSIT APEX SYSTEMSDIR DEP (Cash)",
+        "description": "DIRECT DEPOSIT ACME STAFFINGDIR DEP (Cash)",
         "amount": "-1428.61",
     }
     row = normalize_transaction(account, deposit, "2026-07-31T00:00:00Z")
@@ -200,23 +200,26 @@ def test_retirement_account_activity_is_not_household_spending() -> None:
 def test_inbound_direct_deposits_are_payroll_regardless_of_employer_memo() -> None:
     """Employers vary the memo suffix; the deposit is payroll either way.
 
-    Verified 2026-08-31: Christian Brothers, Goucher and one Actalent variant say
-    "PAYROLL" and tagged correctly, while APEX Systems ("DIR DEP") and Actalent's
-    "ACH" variant fell through to Uncategorized, leaving $41,763.89 of income
-    untagged. The verification micro-deposits must stay Exempt.
+    Verified 2026-08-31 against a real feed: payers whose memo ends in "PAYROLL"
+    tagged correctly, while payers ending in "DIR DEP" or a plain "ACH" variant
+    fell through to Uncategorized, leaving a large share of income untagged. The
+    verification micro-deposits must stay Exempt.
+
+    Employer names and amounts below are placeholders; the memo SHAPE is what is
+    under test, and real payer names do not belong in a public repository.
     """
     cma = "Cash Management (Joint WROS) (4752)"
     assert (
-        categorize_expense("DIRECT DEPOSIT APEX SYSTEMSDIR DEP (Cash)", 2207.38, cma)
+        categorize_expense("DIRECT DEPOSIT ACME STAFFINGDIR DEP (Cash)", 2207.38, cma)
         == "Payroll"
     )
     assert (
-        categorize_expense("DIRECT DEPOSIT Actalent SerACH (Cash)", 2273.03, cma)
+        categorize_expense("DIRECT DEPOSIT Ridgeline SerACH (Cash)", 2273.03, cma)
         == "Payroll"
     )
     # Already-working variants must not regress.
     assert (
-        categorize_expense("DIRECT DEPOSIT GOUCHER COLLPAYROLL (Cash)", 2431.51, cma)
+        categorize_expense("DIRECT DEPOSIT NORTHFIELD COLLPAYROLL (Cash)", 2431.51, cma)
         == "Payroll"
     )
     # Sub-dollar bank verification deposits stay Exempt, not payroll.


### PR DESCRIPTION
## Problem

Reconciling the Fidelity CMA feed against the authoritative SnapTrade
`transactions` rows turned up a duplicated transaction, and chasing it surfaced
three separate defects in the SimpleFIN ingest path.

1. **Direction was resolved from the amount sign.** Fidelity gets that sign
   wrong in both directions, not just one. Inbound payroll arrives negative and
   debit-card purchases and cash advances arrive positive, so purchases, cash
   advances, and both legs of an internal transfer were mis-signed. The two legs
   of a transfer share a sign, so nothing but the feed wording separates them.

2. **Retirement account activity was booked as household spending.** The plan
   feed reports biweekly contributions with the bare memo `contribution`, which
   the text table read as `Uncategorized` and counted as consumption. That was
   $307.70 of phantom August spend.

3. **Inbound payroll only matched employers whose ACH memo ended in `PAYROLL`.**
   Payers that end the memo differently (`DIR DEP`, a plain `ACH` variant) never
   matched, leaving a five-figure sum of income untagged. Matching on the memo
   suffix is structurally wrong: an inbound direct deposit is income by
   definition, whoever sends it.

Separately, categorization matched only `description`, the raw bank memo, and
ignored `payee`, SimpleFIN's normalized merchant name. That alone left 67% of
30-day debit volume in `Uncategorized`, and an ordering bug sent credit card
payments to `Loan Payment`.

## How it was solved

Each defect was fixed test-first, with the new test run and confirmed red before
the change.

- `resolve_direction` now prefers explicit feed wording over the sign, with
  markers for debit-card purchases, cash advances, and `transferred to` /
  `transferred from`. The sign remains the fallback for feeds that get it right.
- The account name decides before any text pattern runs. Everything on a
  retirement account resolves to `Retirement`, since `contribution` alone is too
  generic to match on safely (a charitable contribution is real spending).
- Payroll matches on `direct deposit` itself rather than a memo suffix.
  Sub-dollar bank verification deposits are already returned `Exempt` by the
  amount rule before the payroll table is reached.
- Categorization matches on `payee` and `description` joined, and gains
  `Credit Card Payment`, `Giving`, `Fees & Interest`, `Retirement`, and
  `Payroll`. A new `NON_SPEND_CATEGORIES` set keeps transfers and card payments
  out of spend totals so a card purchase is not counted twice.

Business-account detection keys off generic substrings only (`business`, `llc`).
Entity names are private data, so extra hints are supplied at runtime through
`FG_BUSINESS_ACCOUNT_HINTS` rather than committed to the repo. Both existing
business accounts still resolve correctly on the generic hints alone, so
behavior is unchanged.

## Verification

- `uv run pytest tests/python` : 1055 passed, 2 skipped
- `uv run ruff check`, `uv run ruff format --check`, `uv run mypy src/` : clean
- All pre-commit hooks pass, including the coverage gate and gitleaks
- `compliance-scan --scope push` : PASS, no findings

9 files changed.

---

Changes made by Claude Opus 5 in Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved expense categorization using both payee and transaction descriptions.
  - Correctly identifies credit card payments, transfers, payroll, retirement activity, giving, and fees.
  - Improved handling of debit-card purchases, cash advances, and internal transfers.
  - Excludes non-spending transactions from expense totals.
  - Added configurable business-account detection and enhanced privacy protections.

- **Documentation**
  - Documented one-session price freshness delays and guidance for current-market valuation.
  - Clarified sync completion checks, transaction coverage, categorization rules, and dividend timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->