### PR TITLE
chore(privacy): rewrite standing financial figures as ratios per DataClassification

### DIFF
--- a/.claude/commands/fin-guru/agents/compliance-officer.md
+++ b/.claude/commands/fin-guru/agents/compliance-officer.md
@@ -163,7 +163,7 @@
 
       <step1-output>
         TSLA is ITC-supported (tradfi universe).
-        Current holding: $32,698 (13.42% of portfolio).
+        Current holding: 13.42% of portfolio.
       </step1-output>
 
       <step2-output>

--- a/.claude/skills/FinanceReport/SKILL.md
+++ b/.claude/skills/FinanceReport/SKILL.md
@@ -112,7 +112,7 @@ Shows BOTH percentage AND dollar amount:
 ```
 Recommended Allocation: 2-3%
 For $250,000 portfolio:
-  - Dollar amount: $5,000 - $7,500
+  - Dollar amount: 2-3% of the $250,000 example portfolio
   - Share count: ~25-38 shares at $200
 ```
 

--- a/.claude/skills/FinanceReport/workflows/FullResearchWorkflow.md
+++ b/.claude/skills/FinanceReport/workflows/FullResearchWorkflow.md
@@ -136,9 +136,9 @@ Create investment thesis integrating:
 ```python
 # Based on $250k portfolio and conviction level
 SIZING_MATRIX = {
-    "STRONG BUY": 3.0,      # 3% = $7,500
-    "BUY": 2.5,             # 2.5% = $6,250
-    "CONDITIONAL BUY": 2.0, # 2% = $5,000
+    "STRONG BUY": 3.0,      # 3% of portfolio
+    "BUY": 2.5,             # 2.5% of portfolio
+    "CONDITIONAL BUY": 2.0, # 2% of portfolio
     "HOLD": 0,              # No new position
     "SELL": 0               # Exit existing
 }
@@ -230,7 +230,7 @@ PHASE 2: Quant Analysis
 PHASE 3: Strategy
 ├─ Rating: STRONG BUY
 ├─ Conviction: 8.3/10
-├─ Sizing: 3% = $7,500 (33 shares at $226)
+├─ Sizing: 3% of portfolio (33 shares at $226)
 └─ Entry: Scale-in over 2 weeks
 
 PHASE 4: Report

--- a/.claude/skills/FinanceReport/workflows/GenerateSingleReport.md
+++ b/.claude/skills/FinanceReport/workflows/GenerateSingleReport.md
@@ -50,7 +50,7 @@ uv run python src/utils/market_data.py {TICKER}
 
 Based on user profile ($250k default):
 - Recommended allocation: 2-3% for moderate conviction
-- Dollar amount: $5,000 - $7,500
+- Dollar amount: 2-3% of portfolio value
 - Share count: Calculate from current price
 
 ### Step 5: Generate PDF Report
@@ -124,7 +124,7 @@ User: "Generate a report for NVDA"
    → 25 Buy, 8 Hold, 2 Sell, Target: $165
 
 4. Calculate sizing for $250k portfolio
-   → 2.5% = $6,250 = ~45 shares at $138
+   → 2.5% of portfolio = ~45 shares at $138
 
 5. Generate PDF
    → fin-guru-private/fin-guru/analysis/reports/NVDA-analysis-2025-12-18.pdf (32KB)

--- a/.claude/skills/MonteCarlo/PortfolioParser.md
+++ b/.claude/skills/MonteCarlo/PortfolioParser.md
@@ -125,7 +125,7 @@ Alternatively, check the "Pending activity" row in positions CSV which shows the
 ## Example Output
 
 ```python
->>> parse_portfolio('notebooks/updates/Portfolio_Positions_Jan-02-2026.csv')
+>>> parse_portfolio('notebooks/updates/Portfolio_Positions_REDACTED.csv')
 {
     'layer1': 170073.42,
     'layer2': 61725.18,
@@ -140,9 +140,9 @@ Alternatively, check the "Pending activity" row in positions CSV which shows the
 ### Duplicate Positions
 Same ticker in margin AND cash accounts:
 ```
-JEPI (Margin): $4,212.85
-JEPI (Cash): $2,059.83
-Total JEPI: $6,272.68
+JEPI (Margin): ~67% of the combined position
+JEPI (Cash): ~33% of the combined position
+Total JEPI: margin + cash summed
 ```
 
 The parsing algorithm sums both positions automatically.

--- a/.claude/skills/MonteCarlo/SKILL.md
+++ b/.claude/skills/MonteCarlo/SKILL.md
@@ -55,7 +55,7 @@ User: "What's my margin call probability?"
 ### Portfolio Metrics
 - **Total portfolio value** - Median, P5, P95 at month 28
 - **Layer 1 (Growth)** - PLTR, TSLA, VOO, etc. (no new deployment)
-- **Layer 2 (Income)** - Dividend funds ($11,517/month deployment)
+- **Layer 2 (Income)** - Dividend funds (recurring W2-funded monthly deployment)
 - **Layer 3 (Hedge)** - SQQQ ($800/month deployment)
 - **GOOGL position** - Scale-in ($1,000/month deployment)
 

--- a/.claude/skills/MonteCarlo/workflows/IncorporateBuyTicket.md
+++ b/.claude/skills/MonteCarlo/workflows/IncorporateBuyTicket.md
@@ -39,7 +39,7 @@ Example buy ticket format:
 ```markdown
 ---
 document_type: buy-ticket
-deployment_amount: "$5,054.09"
+deployment_amount: "$5,000.00"
 cash_available: "$6,000.00"
 price_snapshot_as_of: "2026-01-31T09:45:00-05:00"
 ---
@@ -117,20 +117,20 @@ Note in the output that this simulation includes the buy ticket:
 1. Find ticket: `fin-guru-private/fin-guru/tickets/buy-ticket-2025-12-31-w2-payroll.md`
 
 2. Parse allocations:
-   - JEPI: $500
-   - JEPQ: $500
-   - CLM: $500
-   - SQQQ: $800
+   - JEPI: 10% of ticket total
+   - JEPQ: 10% of ticket total
+   - CLM: 10% of ticket total
+   - SQQQ: 16% of ticket total
    - etc.
 
 3. Categorize:
-   - Layer 2: $4,254.09
-   - Layer 3: $800
-   - Total: $5,054.09
+   - Layer 2: ~84% of ticket total
+   - Layer 3: ~16% of ticket total
+   - Total: ticket total = 100%
 
 4. Adjust starting values:
-   - Layer 2: $61,725 + $4,254 = $65,979
-   - Layer 3: $13,199 + $800 = $13,999
+   - Layer 2: starting balance increased ~7% after the deployment
+   - Layer 3: starting balance increased ~6% after the deployment
 
 5. Run simulation with adjusted values
 

--- a/.claude/skills/MonteCarlo/workflows/RunSimulation.md
+++ b/.claude/skills/MonteCarlo/workflows/RunSimulation.md
@@ -128,7 +128,7 @@ Present key metrics to the user:
 | MSTR | Bitcoin proxy |
 | PARR | New growth position |
 
-### Layer 2 (Income) - Build with W2, $11,517/month
+### Layer 2 (Income) - Build with recurring W2 monthly deployment
 | Bucket | Tickers | Allocation |
 |--------|---------|------------|
 | JPMorgan Income | JEPI, JEPQ | 27% |

--- a/.claude/skills/retirement-syncing/SKILL.md
+++ b/.claude/skills/retirement-syncing/SKILL.md
@@ -138,11 +138,11 @@ the numbers as accurate.
 **Log Summary:**
 ```
 Updated 12 retirement positions:
-- VOO: 214.7947 shares
-- VUG: 13.0652 shares
-- VTSAX: 228.462 shares
+- VOO: NNN.NNNN shares
+- VUG: NN.NNNN shares
+- VTSAX: NNN.NNN shares
 ...
-Total Retirement Value: ~$387,806
+Total Retirement Value: sum of updated position values
 ```
 
 ## Critical Rules

--- a/.dev/specs/archive/finance-guru-tui-dashboard.md
+++ b/.dev/specs/archive/finance-guru-tui-dashboard.md
@@ -104,7 +104,7 @@ src/ui/
 #### Main Screen (Primary View)
 ```
 ┌─ Finance Guru™ Dashboard ─────────────────────────────────────────┐
-│ Portfolio: $222,214.99 | Day: -$4,091 (-1.80%) | Nov 17 2025 3:33p│ <- PortfolioHeader
+│ Portfolio: $XXX,XXX.XX | Day: -1.80% | Nov 17 2025 3:33p         │ <- PortfolioHeader
 ├───────────────────────────────────────────────────────────────────┤
 │ [1] Layer 1  [2] Layer 2  [3] Layer 3  [4] Momentum  [5] Vol     │ <- QuickNav
 │ [6] Risk     [7] Golden Cross  [8] Portfolio  [R] Refresh [Q] Quit│

--- a/.dev/specs/archive/itc-risk-api-integration.md
+++ b/.dev/specs/archive/itc-risk-api-integration.md
@@ -611,7 +611,7 @@ if not self.api_key:
 ```
 📚 UNDERSTANDING RISK BANDS:
    Risk bands show how risk changes with price movement.
-   Example: TSLA at $450 = 0.49 risk, at $1526 = 0.99 risk
+   Example: TSLA at $450 = 0.49 risk, at $1,000 = 0.99 risk
 
    Use this to:
    - Set alerts when approaching high-risk zones

--- a/.dev/specs/archive/itc-risk-api-integration.md
+++ b/.dev/specs/archive/itc-risk-api-integration.md
@@ -611,7 +611,7 @@ if not self.api_key:
 ```
 📚 UNDERSTANDING RISK BANDS:
    Risk bands show how risk changes with price movement.
-   Example: TSLA at $450 = 0.49 risk, at $1,000 = 0.99 risk
+   Example (illustrative, synthetic values): TSLA at $450 = 0.49 risk, at $1,000 = 0.99 risk
 
    Use this to:
    - Set alerts when approaching high-risk zones

--- a/.memory/notes/automated-buy-ticket-agent-architecture.md
+++ b/.memory/notes/automated-buy-ticket-agent-architecture.md
@@ -102,7 +102,7 @@ Fidelity has no retail API. Options:
 | Schwab   | ⚠️ Individual approval    | 7-9%          | Slow onboarding                |
 | Alpaca   | ✅ Clean REST              | Stocks only   | Wrong universe for Layer 2     |
 
-**Honest take:** True execution automation requires moving the trading account to IBKR. Keep Fidelity as operating/banking. IBKR's 2.5-4.5% rate alone saves several hundred basis points a year on the current margin balance vs Fidelity 6-8%.
+**Honest take:** True execution automation requires moving the trading account to IBKR. Keep Fidelity as operating/banking. IBKR's 2.5-4.5% rate is potentially 150-550 basis points below Fidelity's 6-8%; annual dollar savings depend on the balance and applicable rates.
 
 ---
 

--- a/.memory/notes/automated-buy-ticket-agent-architecture.md
+++ b/.memory/notes/automated-buy-ticket-agent-architecture.md
@@ -102,7 +102,7 @@ Fidelity has no retail API. Options:
 | Schwab   | ⚠️ Individual approval    | 7-9%          | Slow onboarding                |
 | Alpaca   | ✅ Clean REST              | Stocks only   | Wrong universe for Layer 2     |
 
-**Honest take:** True execution automation requires moving the trading account to IBKR. Keep Fidelity as operating/banking. IBKR's 2.5-4.5% rate alone saves ~$1,800/yr on current $45.7K margin balance vs Fidelity 6-8%.
+**Honest take:** True execution automation requires moving the trading account to IBKR. Keep Fidelity as operating/banking. IBKR's 2.5-4.5% rate alone saves several hundred basis points a year on the current margin balance vs Fidelity 6-8%.
 
 ---
 

--- a/config/fidelity-mapping.json
+++ b/config/fidelity-mapping.json
@@ -14,13 +14,13 @@
       "quantity": {
         "fidelity_column": "Quantity",
         "data_type": "number",
-        "example": "74",
+        "example": "100",
         "notes": "Number of shares owned"
       },
       "average_cost_basis": {
         "fidelity_column": "Average Cost Basis",
         "data_type": "currency",
-        "example": "$234.19",
+        "example": "$150.00",
         "notes": "Average purchase price per share"
       }
     },
@@ -28,17 +28,17 @@
       "last_price": {
         "fidelity_column": "Last Price",
         "data_type": "currency",
-        "example": "$448.96"
+        "example": "$200.00"
       },
       "current_value": {
         "fidelity_column": "Current Value",
         "data_type": "currency",
-        "example": "$33223.04"
+        "example": "$20000.00"
       },
       "total_gain_loss_dollar": {
         "fidelity_column": "Total Gain/Loss Dollar",
         "data_type": "currency",
-        "example": "+$15892.97"
+        "example": "+$5000.00"
       },
       "total_gain_loss_percent": {
         "fidelity_column": "Total Gain/Loss Percent",
@@ -76,7 +76,7 @@
       "net_debit": {
         "fidelity_key": "Net debit",
         "data_type": "currency",
-        "example": "$(7822.71)",
+        "example": "$(5000.00)",
         "notes": "Margin debt (negative value)"
       },
       "account_equity_percentage": {
@@ -88,7 +88,7 @@
       "total_account_value": {
         "fidelity_key": "Total account value",
         "data_type": "currency",
-        "example": "252103.3",
+        "example": "200000.00",
         "notes": "Total portfolio value"
       }
     },
@@ -110,7 +110,7 @@
     "format_notes": "Two-column format: first column is field name, second column is value. Commas as delimiters.",
     "example_rows": [
       ",Balance,Day change",
-      "Total account value,252103.3,-818.25",
+      "Total account value,200000.00,-500.00",
       "Account equity percentage,97.87%,"
     ]
   },
@@ -137,12 +137,12 @@
       "description": {
         "fidelity_column": "Description",
         "data_type": "string",
-        "example": "H-E-B #458"
+        "example": "H-E-B #100"
       },
       "amount": {
         "fidelity_column": "Amount ($)",
         "data_type": "currency",
-        "example": "$51.63"
+        "example": "$50.00"
       },
       "cash_balance": {
         "fidelity_column": "Cash Balance ($)",
@@ -360,12 +360,12 @@
       "quantity": {
         "fidelity_column": "Quantity",
         "data_type": "number",
-        "example": "72.942"
+        "example": "100.000"
       },
       "amount_per_share": {
         "fidelity_column": "Amount per share",
         "data_type": "currency",
-        "example": "$0.7080"
+        "example": "$0.5000"
       },
       "pay_date": {
         "fidelity_column": "Pay date",
@@ -381,7 +381,7 @@
     }
   },
   "parsing_notes": {
-    "currency_format": "US format with $ prefix, commas for thousands, periods for decimals. Negative values use parentheses: $(7822.71)",
+    "currency_format": "US format with $ prefix, commas for thousands, periods for decimals. Negative values use parentheses: $(5000.00)",
     "percentage_format": "Decimal followed by % symbol: 97.87%",
     "date_format": "MM/DD/YYYY",
     "special_characters": "UTF-8 BOM at start of file (\\ufeff)",


### PR DESCRIPTION
## Problem

The layer-7 compliance scanner added in PR #128 flagged 25 standing findings across 12 tracked docs on `main`: precise currency amounts (household balances, margin debt, income, share quantities) written into documentation and workflow examples, in violation of `.claude/skills/compliance-scan/references/DataClassification.md`'s rule that docs describe behaviour as shapes (percentages, ratios, counts) rather than absolute amounts. A 13th file, `config/fidelity-mapping.json`, separately carried real-looking example values (including a real share quantity) in its schema documentation.

## Approach

For each finding, judged whether the value was a genuinely synthetic worked example or real household data:
- Synthetic scenario values (e.g. formulas off a round `$250k` example portfolio, a generic buy-ticket format example, a stock-price risk-band illustration) were rounded to obviously fake, round numbers.
- Real-looking data (non-round amounts, cents, values matching other real household figures across files) was rewritten as percentages, ratios, or counts per the DataClassification.md table — same teaching value, no absolute figure.
- `config/fidelity-mapping.json`'s example values (share quantity, cost basis, prices, gain/loss, net debit, total account value, dividend rate/quantity, a store number) were swapped for obviously fake round numbers; percentages were left as-is since ratios are explicitly public under the policy.
- One collateral finding (a dated CSV filename example in `PortfolioParser.md` matching an existing PII filename rule, pre-dating this backlog) was also redacted since it lived in a file already being touched and blocked pushes on that file.

No commit in this branch ever held a real figure — every line was rewritten in place, not added then removed.

## Verification

- Layer-7 scan (scanner version from `fix/simplefin-privacy-hardening` at dispatch time) on the 12 backlog files: 25 -> 0 findings.
- Repo's installed `scan.py --scope push`: PASS, no findings, on the full branch diff.
- `git diff origin/main...HEAD` reviewed by hand against a currency regex: only round/synthetic values remain in added lines.
- `uv run pytest tests/python/ -q --no-cov`: 990 passed, 2 skipped.
- `uv run ruff check .`: all checks passed.
- Pre-commit hooks (secret detection, pytest, whitespace/EOF, etc.): all passed on the commit.

Note: the scrub targeted the 25 findings present on the PR #128 head at dispatch time. That branch has since tightened the layer-7 regex to also catch sub-$1,000 amounts with cents; a few residual findings may surface in these same files once #128 merges and the new regex runs against `main`. Those are follow-up work, not addressed here, per instruction not to re-scrub against a moving scanner target.

---
Written by Claude Sonnet 5 in Claude Code (dispatched by Opus).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated finance, risk, portfolio-sizing, and retirement examples to use percentage-based, synthetic, or placeholder values.
  * Refined investment allocation and recurring-deployment examples for greater flexibility.
  * Updated sample portfolio, dashboard, and market-risk values to generic or revised examples.
  * Clarified that certain risk-model figures are illustrative and that savings estimates depend on applicable rates and balances.
* **Configuration**
  * Refreshed Fidelity mapping example values without changing supported fields or parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->