### PR TITLE
feat(config): resolve every private path from one instance data root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,11 @@ SNAPTRADE_CONSUMER_KEY=your_snaptrade_consumer_key_here
 SNAPTRADE_USER_ID=your_snaptrade_user_id_here
 SNAPTRADE_USER_SECRET=your_snaptrade_user_secret_here
 
-# Database
+# Instance data root. Every private file (profile, DB, CSV imports, tickets, strategies)
+# lives under this directory. Defaults to the current working directory.
+FIN_GURU_DATA_ROOT=
+
+# Database (optional; defaults to family_office.db under the instance data root)
 DATABASE_URL=sqlite:///family_office.db
 
 # SimpleFIN (optional local bank/card sync)

--- a/buy_ticket_agent/config.py
+++ b/buy_ticket_agent/config.py
@@ -7,12 +7,15 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict
 
+from src.config.instance_paths import InstancePaths
+
 
 class SmokePaths(BaseModel):
     """Filesystem destinations used by the smoke path."""
 
     model_config = ConfigDict(frozen=True)
 
+    instance_root: Path
     project_root: Path
     drafts_dir: Path
     runs_dir: Path
@@ -20,19 +23,16 @@ class SmokePaths(BaseModel):
     state_db: Path
 
     @classmethod
-    def from_project_root(cls, project_root: Path | None = None) -> SmokePaths:
-        """Build default smoke output paths from the repository root."""
-        root = project_root or Path.cwd()
+    def from_instance(cls, paths: InstancePaths | None = None) -> SmokePaths:
+        """Build smoke output paths from one resolved instance layout."""
+        instance_paths = paths or InstancePaths.resolve()
         return cls(
-            project_root=root,
-            drafts_dir=root
-            / "fin-guru-private"
-            / "fin-guru"
-            / "tickets"
-            / "auto-drafts",
-            runs_dir=root / "notebooks" / "auto-tickets" / "runs",
-            bundles_dir=root / "notebooks" / "auto-tickets" / "bundles",
-            state_db=root / "notebooks" / "auto-tickets" / "state.db",
+            instance_root=instance_paths.root,
+            project_root=Path(__file__).resolve().parent.parent,
+            drafts_dir=instance_paths.tickets / "auto-drafts",
+            runs_dir=instance_paths.auto_tickets / "runs",
+            bundles_dir=instance_paths.auto_tickets / "bundles",
+            state_db=instance_paths.auto_tickets / "state.db",
         )
 
 

--- a/buy_ticket_agent/main.py
+++ b/buy_ticket_agent/main.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import sys
 from dataclasses import asdict
-from pathlib import Path
 
 from buy_ticket_agent.pipeline import run_smoke_for_cli
 from buy_ticket_agent.secrets import SecretAccessError
@@ -35,7 +34,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     try:
-        result = run_smoke_for_cli(project_root=Path.cwd())
+        result = run_smoke_for_cli()
     except SecretAccessError as exc:
         print(f"Secret access blocker: {exc}", file=sys.stderr)
         return 1

--- a/buy_ticket_agent/pipeline.py
+++ b/buy_ticket_agent/pipeline.py
@@ -25,6 +25,7 @@ from buy_ticket_agent.state import (
     record_smoke_failure,
     record_smoke_run,
 )
+from src.config.instance_paths import InstancePaths
 
 SMOKE_TICKER = "SPY"
 ITC_PROXY_TICKER = "SP500"
@@ -129,6 +130,19 @@ def _relative(path: Path, root: Path) -> str:
         return str(path.relative_to(root))
     except ValueError:
         return str(path)
+
+
+def _resolve_smoke_paths(
+    instance_paths: InstancePaths | None,
+    project_root: Path | None,
+) -> SmokePaths:
+    """Resolve instance storage while retaining a source-root test override."""
+    if instance_paths is None and project_root is not None:
+        instance_paths = InstancePaths(root=project_root.resolve())
+    paths = SmokePaths.from_instance(instance_paths)
+    if project_root is None:
+        return paths
+    return paths.model_copy(update={"project_root": project_root.resolve()})
 
 
 def _output_length(output: str | bytes | None) -> int:
@@ -401,6 +415,7 @@ def run(
     tickers: list[str] | tuple[str, ...],
     *,
     universe: str = "tradfi",
+    instance_paths: InstancePaths | None = None,
     project_root: Path | None = None,
     timeout_seconds: int = 55,
     days: int = 90,
@@ -409,7 +424,7 @@ def run(
     """Run the deterministic AOJ-460 Layer 3 pipeline and persist its bundle."""
     normalized_tickers = _normalize_tickers(tickers)
     validated_universe = _validate_universe(universe)
-    paths = SmokePaths.from_project_root(project_root)
+    paths = _resolve_smoke_paths(instance_paths, project_root)
     now = _utc_now()
     created_at = now.isoformat()
     run_id = f"layer3-{now:%Y%m%d}-{uuid4().hex[:8]}"
@@ -436,8 +451,8 @@ def run(
         primary_ticker=normalized_tickers[0],
         tickers=list(normalized_tickers),
         universe=validated_universe,
-        bundle_path=_relative(bundle_path, paths.project_root),
-        state_db=_relative(paths.state_db, paths.project_root),
+        bundle_path=_relative(bundle_path, paths.instance_root),
+        state_db=_relative(paths.state_db, paths.instance_root),
         itc=tool_results["itc"],
         risk=tool_results["risk"],
         mom=tool_results["mom"],
@@ -453,7 +468,7 @@ def run(
         primary_ticker=normalized_tickers[0],
         tickers=normalized_tickers,
         status=bundle.status,
-        bundle_path=_relative(bundle_path, paths.project_root),
+        bundle_path=_relative(bundle_path, paths.instance_root),
         payload=payload,
     )
     return payload
@@ -564,9 +579,12 @@ def _make_ticket_payload(
     return payload
 
 
-def run_smoke(project_root: Path | None = None) -> SmokeResult:
+def run_smoke(
+    instance_paths: InstancePaths | None = None,
+    project_root: Path | None = None,
+) -> SmokeResult:
     """Run the AOJ-458 end-to-end smoke path."""
-    paths = SmokePaths.from_project_root(project_root)
+    paths = _resolve_smoke_paths(instance_paths, project_root)
     now = _utc_now()
     created_at = now.isoformat()
     run_id = f"smoke-{now:%Y%m%d}-{uuid4().hex[:8]}"
@@ -590,7 +608,7 @@ def run_smoke(project_root: Path | None = None) -> SmokeResult:
             "created_at": created_at,
             "status": status,
             "draft_path": None,
-            "state_db": _relative(paths.state_db, paths.project_root),
+            "state_db": _relative(paths.state_db, paths.instance_root),
             "trigger": trigger_context,
             "layer3": asdict(cli_result),
             "notification": None,
@@ -608,8 +626,8 @@ def run_smoke(project_root: Path | None = None) -> SmokeResult:
             ticket_id=None,
             status=status,
             draft_path=None,
-            log_path=_relative(log_path, paths.project_root),
-            state_db=_relative(paths.state_db, paths.project_root),
+            log_path=_relative(log_path, paths.instance_root),
+            state_db=_relative(paths.state_db, paths.instance_root),
             notification=None,
         )
 
@@ -639,8 +657,8 @@ def run_smoke(project_root: Path | None = None) -> SmokeResult:
         "ticket_id": ticket_id,
         "created_at": created_at,
         "status": status,
-        "draft_path": _relative(draft_path, paths.project_root),
-        "state_db": _relative(paths.state_db, paths.project_root),
+        "draft_path": _relative(draft_path, paths.instance_root),
+        "state_db": _relative(paths.state_db, paths.instance_root),
         "trigger": trigger_context,
         "layer3": asdict(cli_result),
         "notification": asdict(notification),
@@ -662,13 +680,16 @@ def run_smoke(project_root: Path | None = None) -> SmokeResult:
         run_id=run_id,
         ticket_id=ticket_id,
         status=status,
-        draft_path=_relative(draft_path, paths.project_root),
-        log_path=_relative(log_path, paths.project_root),
-        state_db=_relative(paths.state_db, paths.project_root),
+        draft_path=_relative(draft_path, paths.instance_root),
+        log_path=_relative(log_path, paths.instance_root),
+        state_db=_relative(paths.state_db, paths.instance_root),
         notification=notification,
     )
 
 
-def run_smoke_for_cli(project_root: Path | None = None) -> SmokeResult:
+def run_smoke_for_cli(
+    instance_paths: InstancePaths | None = None,
+    project_root: Path | None = None,
+) -> SmokeResult:
     """CLI wrapper that surfaces BWS access failures to the caller."""
-    return run_smoke(project_root=project_root)
+    return run_smoke(instance_paths=instance_paths, project_root=project_root)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ dependencies = [
     "snaptrade-python-sdk>=11.0.197",
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src", "buy_ticket_agent"]
+
 [dependency-groups]
 dev = [
     "ruff>=0.12.0",

--- a/src/analysis/hedge_sizer.py
+++ b/src/analysis/hedge_sizer.py
@@ -35,7 +35,7 @@ ALLOCATION:
 
 PORTFOLIO VALUE CASCADE:
     1. CLI flag (--portfolio-value)
-    2. Fidelity CSV (notebooks/updates/Balances_for_Account_*.csv)
+    2. Fidelity CSV (imports/Balances_for_Account_*.csv under the instance root)
     3. ValueError if nothing found
 
 BUDGET VALIDATION:
@@ -56,12 +56,12 @@ import contextlib
 import io
 import logging
 import math
-import os
 import statistics
 from glob import glob
 from pathlib import Path
 
 from src.config.config_loader import HedgeConfig
+from src.config.instance_paths import InstancePaths
 
 logger = logging.getLogger(__name__)
 
@@ -69,24 +69,8 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-"""Project root directory (three levels up from src/analysis/hedge_sizer.py)."""
-
 DEFAULT_RATIO_PER_CONTRACT = 50_000.0
 """Default portfolio value per contract: $50,000. HS-01."""
-
-PORTFOLIO_DIR = Path(
-    os.getenv("FIN_GURU_PORTFOLIO_DIR", str(PROJECT_ROOT / "notebooks" / "updates"))
-)
-"""Directory holding broker export CSVs (balances, positions, transactions).
-
-Override with ``FIN_GURU_PORTFOLIO_DIR`` for testing or portable deployment.
-Matches the env var convention in ``src/config/fin_guru_config.py``.
-"""
-
-BALANCES_GLOB = str(PORTFOLIO_DIR / "Balances_for_Account_*.csv")
-"""Glob pattern for Fidelity balance CSV files."""
-
 
 # ---------------------------------------------------------------------------
 # Module-level helper functions
@@ -163,17 +147,17 @@ def allocate_contracts(
 def read_portfolio_value_from_csv() -> float | None:
     """Read total account value from latest Fidelity balance CSV.
 
-    Searches the configured portfolio directory (``FIN_GURU_PORTFOLIO_DIR``,
-    default ``notebooks/updates/``) via ``BALANCES_GLOB``, picks the most
-    recently modified ``Balances_for_Account_*.csv`` file, and extracts the
-    "Total account value" row.
+    Searches the ``imports`` directory under the resolved instance root, picks
+    the most recently modified ``Balances_for_Account_*.csv`` file, and
+    extracts the "Total account value" row.
 
     Returns:
         Portfolio value as float, or None if not found / parse error.
     """
-    csv_files = sorted(glob(BALANCES_GLOB), key=lambda p: Path(p).stat().st_mtime)
+    balances_glob = str(InstancePaths.resolve().imports / "Balances_for_Account_*.csv")
+    csv_files = sorted(glob(balances_glob), key=lambda p: Path(p).stat().st_mtime)
     if not csv_files:
-        logger.debug("No Fidelity balance CSV files found at %s", BALANCES_GLOB)
+        logger.debug("No Fidelity balance CSV files found at %s", balances_glob)
         return None
 
     latest = csv_files[-1]  # most recent by mtime
@@ -252,8 +236,8 @@ class HedgeSizer:
         # 3. No value found
         msg = (
             "No portfolio value found. Provide --portfolio-value flag or "
-            f"ensure a Fidelity balance CSV exists matching {BALANCES_GLOB} "
-            "(override the directory via FIN_GURU_PORTFOLIO_DIR)."
+            "ensure a Fidelity balance CSV exists under "
+            f"{InstancePaths.resolve().imports}."
         )
         raise ValueError(msg)
 

--- a/src/analysis/hedge_sizer_cli.py
+++ b/src/analysis/hedge_sizer_cli.py
@@ -52,6 +52,7 @@ sys.path.insert(0, str(project_root))
 
 from src.analysis.hedge_sizer import HedgeSizer
 from src.config.config_loader import load_hedge_config
+from src.config.instance_paths import InstancePaths
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -344,7 +345,7 @@ def main() -> int:
             print(f"ERROR: {exc}", file=sys.stderr)
             print(
                 "Provide --portfolio flag or ensure a Fidelity balance CSV "
-                "exists at notebooks/updates/Balances_for_Account_*.csv",
+                f"exists under {InstancePaths.resolve().imports}",
                 file=sys.stderr,
             )
             return 1

--- a/src/analysis/margin_metrics.py
+++ b/src/analysis/margin_metrics.py
@@ -20,9 +20,7 @@ from glob import glob
 from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
-
-DEFAULT_PORTFOLIO_DIR = Path("notebooks/updates")
+from src.config.instance_paths import InstancePaths, load_instance_env
 
 
 @dataclass(frozen=True)
@@ -92,10 +90,7 @@ def parse_rate(value: str | None) -> float:
 
 def balances_glob() -> str:
     """Return the configured Fidelity balances glob."""
-    portfolio_dir = Path(
-        os.getenv("FIN_GURU_PORTFOLIO_DIR", str(DEFAULT_PORTFOLIO_DIR))
-    )
-    return str(portfolio_dir / "Balances_for_Account_*.csv")
+    return str(InstancePaths.resolve().imports / "Balances_for_Account_*.csv")
 
 
 def latest_balances_csv() -> Path:
@@ -204,9 +199,9 @@ def read_db_balances(database_url: str | None = None) -> FidelityBalances:
     local DB the single source of truth. Margin debt is the derived loan
     (SnapTrade does not expose it), so accrued interest and day-change are None.
     """
-    from src.integrations.snaptrade.sync_db import _db_path
+    from src.config.instance_paths import _db_path
 
-    db = _db_path(database_url or os.getenv("DATABASE_URL"))
+    db = _db_path(database_url)
     if not db.exists():
         msg = (
             f"No local database at {db}; run the sync-first refresh "
@@ -324,7 +319,7 @@ def metrics_from_runtime(
     ``source="snaptrade"`` reads the SnapTrade API live, and ``source="csv"``
     (or passing ``csv_path``) reads the legacy Fidelity balances CSV instead.
     """
-    load_dotenv()
+    load_instance_env(InstancePaths.resolve())
     if csv_path is not None or source == "csv":
         balances = read_fidelity_balances(csv_path)
     elif source == "snaptrade":

--- a/src/analysis/margin_metrics.py
+++ b/src/analysis/margin_metrics.py
@@ -324,7 +324,7 @@ def metrics_from_runtime(
     ``source="snaptrade"`` reads the SnapTrade API live, and ``source="csv"``
     (or passing ``csv_path``) reads the legacy Fidelity balances CSV instead.
     """
-    load_instance_env(InstancePaths.resolve())
+    load_instance_env(InstancePaths.resolve(), override=False)
     if csv_path is not None or source == "csv":
         balances = read_fidelity_balances(csv_path)
     elif source == "snaptrade":

--- a/src/analysis/margin_metrics.py
+++ b/src/analysis/margin_metrics.py
@@ -173,18 +173,23 @@ def _broker_balances_from_snaptrade(client: Any, account_id: str) -> FidelityBal
 
 
 def read_snaptrade_balances(
-    config_path: str | Path = "config/snaptrade-accounts.yaml",
+    config_path: str | Path | None = None,
 ) -> FidelityBalances:
     """Pull live balances for the first enabled+routed SnapTrade account."""
     from src.integrations.snaptrade.client import SnapTradeClientWrapper
     from src.integrations.snaptrade.models import SnapTradeAccountsConfig
 
-    config = SnapTradeAccountsConfig.from_path(Path(config_path))
+    resolved_config_path = (
+        Path(config_path)
+        if config_path is not None
+        else InstancePaths.resolve().snaptrade_accounts
+    )
+    config = SnapTradeAccountsConfig.from_path(resolved_config_path)
     syncable = config.syncable
     if not syncable:
         msg = (
             "No SnapTrade account is enabled+routed in "
-            f"{config_path}; cannot read margin balances"
+            f"{resolved_config_path}; cannot read margin balances"
         )
         raise ValueError(msg)
     client = SnapTradeClientWrapper.from_env()

--- a/src/analysis/rolling_tracker.py
+++ b/src/analysis/rolling_tracker.py
@@ -36,38 +36,20 @@ from __future__ import annotations
 import contextlib
 import io
 import logging
-import os
 import sys
 from datetime import date
-from pathlib import Path
 
 import yaml
 
 from src.analysis.options import price_option
 from src.analysis.options_chain_cli import scan_chain
 from src.config.config_loader import HedgeConfig
+from src.config.instance_paths import InstancePaths
 from src.models.hedging_inputs import HedgePosition
 from src.models.options_inputs import OptionContractData
 from src.utils.market_data import get_prices
 
 logger = logging.getLogger(__name__)
-
-PROJECT_ROOT = Path(__file__).parent.parent.parent
-"""Project root directory (three levels up from src/analysis/rolling_tracker.py)."""
-
-PRIVATE_DIR = Path(
-    os.getenv("FIN_GURU_PRIVATE_DIR", str(PROJECT_ROOT / "fin-guru-private"))
-)
-"""Base directory for gitignored Finance Guru data.
-
-Override with ``FIN_GURU_PRIVATE_DIR`` for testing or portable deployment.
-"""
-
-HEDGING_DIR = Path(os.getenv("FIN_GURU_HEDGING_DIR", str(PRIVATE_DIR / "hedging")))
-"""Directory containing hedge position and roll history YAML files.
-
-Defaults to ``PRIVATE_DIR/hedging``. Override with ``FIN_GURU_HEDGING_DIR``.
-"""
 
 # Default parameters for pricing
 DEFAULT_IV = 0.30
@@ -183,17 +165,14 @@ def price_american_put(
 def load_positions() -> list[HedgePosition]:
     """Load active hedge positions from positions.yaml.
 
-    Reads ``HEDGING_DIR / "positions.yaml"`` and parses each entry through the
-    HedgePosition Pydantic model. ``HEDGING_DIR`` defaults to
-    ``fin-guru-private/hedging`` and is configurable via the
-    ``FIN_GURU_HEDGING_DIR`` or ``FIN_GURU_PRIVATE_DIR`` environment variables.
-    Invalid entries are skipped with a stderr warning (Pitfall 5: empty YAML
-    returns None, not {}).
+    Reads ``hedging/positions.yaml`` under the resolved instance root and parses
+    each entry through the HedgePosition Pydantic model. Invalid entries are
+    skipped with a stderr warning (Pitfall 5: empty YAML returns None, not {}).
 
     Returns:
         List of validated HedgePosition instances.
     """
-    positions_path = HEDGING_DIR / "positions.yaml"
+    positions_path = InstancePaths.resolve().hedging / "positions.yaml"
     if not positions_path.exists():
         return []
 
@@ -231,7 +210,7 @@ def save_positions(positions: list[HedgePosition]) -> None:
     Args:
         positions: List of HedgePosition instances to persist.
     """
-    positions_path = HEDGING_DIR / "positions.yaml"
+    positions_path = InstancePaths.resolve().hedging / "positions.yaml"
     positions_path.parent.mkdir(parents=True, exist_ok=True)
 
     data = {
@@ -247,7 +226,7 @@ def load_roll_history() -> list[dict]:
     Returns:
         List of roll record dicts. Empty list if file doesn't exist or is empty.
     """
-    history_path = HEDGING_DIR / "roll-history.yaml"
+    history_path = InstancePaths.resolve().hedging / "roll-history.yaml"
     if not history_path.exists():
         return []
 
@@ -270,7 +249,7 @@ def save_roll_history(history: list[dict]) -> None:
     Args:
         history: List of roll record dicts to persist.
     """
-    history_path = HEDGING_DIR / "roll-history.yaml"
+    history_path = InstancePaths.resolve().hedging / "roll-history.yaml"
     history_path.parent.mkdir(parents=True, exist_ok=True)
 
     data = {"rolls": history}

--- a/src/analysis/rolling_tracker_cli.py
+++ b/src/analysis/rolling_tracker_cli.py
@@ -65,6 +65,7 @@ sys.path.insert(0, str(project_root))
 
 from src.analysis.rolling_tracker import RollingTracker
 from src.config.config_loader import load_hedge_config
+from src.config.instance_paths import InstancePaths
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -170,11 +171,10 @@ def handle_status(args: argparse.Namespace, tracker: RollingTracker) -> int:  # 
     lines.append("=" * 80)
 
     if not positions:
-        from src.analysis.rolling_tracker import HEDGING_DIR
-
         lines.append("")
         lines.append("  No active hedge positions.")
-        lines.append(f"  Add positions to {HEDGING_DIR / 'positions.yaml'}")
+        positions_path = InstancePaths.resolve().hedging / "positions.yaml"
+        lines.append(f"  Add positions to {positions_path}")
     else:
         # Table header
         lines.append("")

--- a/src/analysis/total_return.py
+++ b/src/analysis/total_return.py
@@ -32,41 +32,17 @@ Created: 2026-02-17
 
 from __future__ import annotations
 
-import os
 import statistics
 from dataclasses import dataclass, field
 from datetime import date
-from pathlib import Path
 
 import yaml
 
+from src.config.instance_paths import InstancePaths
 from src.models.total_return_inputs import (
     DividendRecord,
     TotalReturnInput,
 )
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-
-PRIVATE_DIR = Path(
-    os.getenv("FIN_GURU_PRIVATE_DIR", str(_PROJECT_ROOT / "fin-guru-private"))
-)
-"""Base directory for gitignored Finance Guru data.
-
-Override with ``FIN_GURU_PRIVATE_DIR`` for testing or portable deployment.
-"""
-
-DIVIDEND_SCHEDULES_PATH = Path(
-    os.getenv(
-        "FIN_GURU_DIVIDEND_SCHEDULES",
-        str(PRIVATE_DIR / "dividend-schedules.yaml"),
-    )
-)
-"""Path to dividend schedule YAML. Missing file is a graceful fallback."""
-
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -122,12 +98,13 @@ def load_dividend_schedules() -> dict:
         Dict mapping ticker -> {frequency: int, label: str}.
         Empty dict if file does not exist (graceful fallback).
 
-    The YAML file lives in fin-guru-private/ which is gitignored.
-    Missing file is normal (first clone, CI environment).
+    The YAML file lives under the resolved instance root. Missing files are
+    normal for a new instance and in CI.
     """
-    if not DIVIDEND_SCHEDULES_PATH.exists():
+    schedules_path = InstancePaths.resolve().dividend_schedules
+    if not schedules_path.exists():
         return {}
-    with open(DIVIDEND_SCHEDULES_PATH) as f:
+    with schedules_path.open() as f:
         data = yaml.safe_load(f)
     if not isinstance(data, dict):
         return {}
@@ -404,5 +381,4 @@ __all__ = [
     "TotalReturnCalculator",
     "TotalReturnResult",
     "load_dividend_schedules",
-    "DIVIDEND_SCHEDULES_PATH",
 ]

--- a/src/analysis/total_return_cli.py
+++ b/src/analysis/total_return_cli.py
@@ -56,6 +56,7 @@ from src.analysis.total_return import (
     TotalReturnCalculator,
     TotalReturnResult,
 )
+from src.config.instance_paths import InstancePaths
 from src.models.total_return_inputs import (
     DividendRecord,
     TotalReturnInput,
@@ -64,10 +65,6 @@ from src.models.total_return_inputs import (
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-PORTFOLIO_CSV_GLOB = str(
-    project_root / "notebooks" / "updates" / "Portfolio_Positions_*.csv"
-)
 
 DISCLAIMER = (
     "DISCLAIMER: For educational purposes only. Not investment advice. "
@@ -177,19 +174,22 @@ def fetch_ticker_data(
 # ---------------------------------------------------------------------------
 
 
-def load_portfolio_shares(csv_glob: str = PORTFOLIO_CSV_GLOB) -> dict[str, float]:
+def load_portfolio_shares(csv_glob: str | None = None) -> dict[str, float]:
     """Load share counts from the latest Portfolio_Positions CSV.
 
-    Reads the most recently dated CSV from notebooks/updates/ and extracts
-    ticker -> share count mapping.
+    Reads the most recently dated CSV from the resolved instance's ``imports``
+    directory and extracts ticker -> share count mapping.
 
     Args:
-        csv_glob: Glob pattern for CSV files.
+        csv_glob: Optional explicit glob pattern for CSV files.
 
     Returns:
         Dict mapping ticker -> quantity of shares. Empty dict if no CSV found.
     """
-    files = sorted(glob.glob(csv_glob))
+    resolved_glob = csv_glob or str(
+        InstancePaths.resolve().imports / "Portfolio_Positions_*.csv"
+    )
+    files = sorted(glob.glob(resolved_glob))
     if not files:
         return {}
 
@@ -566,7 +566,7 @@ def main() -> int:
             )
         else:
             print(
-                "No Portfolio CSV found in notebooks/updates/ -- "
+                f"No Portfolio CSV found under {InstancePaths.resolve().imports}. "
                 "showing per-share amounts only",
                 file=sys.stderr,
             )

--- a/src/cli/onboarding_wizard.py
+++ b/src/cli/onboarding_wizard.py
@@ -33,6 +33,7 @@ from typing import Any
 _project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(_project_root))
 
+from src.config.instance_paths import InstancePaths
 from src.models.onboarding_inputs import OnboardingState, SectionName
 from src.models.yaml_generation_inputs import (
     AllocationStrategy,
@@ -57,7 +58,7 @@ from src.utils.onboarding_sections import (
     run_preferences_section,
     run_summary_section,
 )
-from src.utils.yaml_generator import YAMLGenerator, write_config_files
+from src.utils.yaml_generator import YAMLGenerator
 
 try:
     import questionary
@@ -380,10 +381,10 @@ def generate_config_files(user_data: UserDataInput, project_root: Path) -> None:
     """Generate all configuration files and write to correct locations.
 
     Private config files (user-profile.yaml, config.yaml, system-context.md)
-    are written under fin-guru-private/ via write_config_files().
+    and .env are written under the resolved instance root.
 
-    Project-root files (CLAUDE.md, .env, .claude/mcp.json) are written
-    separately via explicit Path.write_text() to their correct locations.
+    CLAUDE.md and .claude/mcp.json stay under the project root. The instance
+    .env follows the private config files under the resolved instance root.
 
     Args:
         user_data: Validated user data from the onboarding wizard.
@@ -392,10 +393,16 @@ def generate_config_files(user_data: UserDataInput, project_root: Path) -> None:
     template_dir = project_root / _TEMPLATE_DIR
     generator = YAMLGenerator(str(template_dir))
     output = generator.generate_all_configs(user_data)
+    paths = InstancePaths.resolve(cwd=project_root)
 
-    # --- Write private config files to fin-guru-private/ ---
-    private_base = project_root / "fin-guru-private"
-    write_config_files(output, str(private_base))
+    instance_files = {
+        paths.profile: output.user_profile_yaml,
+        paths.config: output.config_yaml,
+        paths.system_context: output.system_context_md,
+    }
+    for file_path, content in instance_files.items():
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content, encoding="utf-8")
 
     # --- Write project-root files with backup ---
 
@@ -405,7 +412,7 @@ def generate_config_files(user_data: UserDataInput, project_root: Path) -> None:
     claude_path.write_text(output.claude_md, encoding="utf-8")
 
     # .env
-    env_path = project_root / ".env"
+    env_path = paths.env_file
     _backup_file(env_path)
     env_path.write_text(output.env_file, encoding="utf-8")
 
@@ -419,9 +426,9 @@ def generate_config_files(user_data: UserDataInput, project_root: Path) -> None:
     # --- Print results ---
     print()
     print("  Generated configuration files:")
-    print(f"    - {private_base / 'fin-guru' / 'data' / 'user-profile.yaml'}")
-    print(f"    - {private_base / 'fin-guru' / 'config.yaml'}")
-    print(f"    - {private_base / 'fin-guru' / 'data' / 'system-context.md'}")
+    print(f"    - {paths.profile}")
+    print(f"    - {paths.config}")
+    print(f"    - {paths.system_context}")
     print(f"    - {claude_path}")
     print(f"    - {env_path}")
     print(f"    - {mcp_path}")
@@ -507,6 +514,7 @@ def run_wizard(dry_run: bool = False) -> None:
 
     # Convert state to validated model
     project_root = Path.cwd()
+    paths = InstancePaths.resolve(cwd=project_root)
     user_data = convert_state_to_user_data(state, str(project_root))
 
     if dry_run:
@@ -519,11 +527,11 @@ def run_wizard(dry_run: bool = False) -> None:
         print(f"    Philosophy: {user_data.preferences.investment_philosophy.value}")
         print()
         print("  [DRY RUN] Files would be written to:")
-        print("    - fin-guru-private/fin-guru/data/user-profile.yaml")
-        print("    - fin-guru-private/fin-guru/config.yaml")
-        print("    - fin-guru-private/fin-guru/data/system-context.md")
+        print(f"    - {paths.profile}")
+        print(f"    - {paths.config}")
+        print(f"    - {paths.system_context}")
         print(f"    - {project_root / 'CLAUDE.md'}")
-        print(f"    - {project_root / '.env'}")
+        print(f"    - {paths.env_file}")
         print(f"    - {project_root / '.claude' / 'mcp.json'}")
         print()
         # Deactivate handler and clean up progress on dry-run completion too

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -5,18 +5,19 @@ Provides validated configuration loading for hedging and portfolio tools.
 Re-exports:
     FinGuruConfig: TUI dashboard configuration (layers, paths)
     HedgeConfig: Hedging strategy configuration model
+    InstancePaths: Resolved private instance layout
     load_hedge_config: Load and merge hedging config from YAML + CLI overrides
+    load_instance_env: Load the instance-specific .env file
 """
 
+from src.config.config_loader import HedgeConfig, load_hedge_config
 from src.config.fin_guru_config import FinGuruConfig
+from src.config.instance_paths import InstancePaths, load_instance_env
 
-__all__: list[str] = ["FinGuruConfig"]
-
-# HedgeConfig and load_hedge_config from config_loader.py.
-# Conditionally imported to avoid breaking when config_loader doesn't exist yet.
-try:
-    from src.config.config_loader import HedgeConfig, load_hedge_config
-
-    __all__ += ["HedgeConfig", "load_hedge_config"]
-except ImportError:
-    pass
+__all__ = [
+    "FinGuruConfig",
+    "HedgeConfig",
+    "InstancePaths",
+    "load_hedge_config",
+    "load_instance_env",
+]

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -25,16 +25,9 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from src.config.instance_paths import InstancePaths
+
 logger = logging.getLogger(__name__)
-
-PROJECT_ROOT = Path(__file__).parent.parent.parent
-"""Project root directory (three levels up from src/config/config_loader.py)."""
-
-_PROFILE_SEARCH_PATHS = [
-    PROJECT_ROOT / "fin-guru-private" / "data" / "user-profile.yaml",
-    PROJECT_ROOT / "fin-guru" / "data" / "user-profile.yaml",
-]
-"""Ordered list of paths to search for user-profile.yaml."""
 
 
 class HedgeConfig(BaseModel):
@@ -155,8 +148,8 @@ def load_hedge_config(
     """Load hedging configuration with the priority chain: CLI > YAML > defaults.
 
     Args:
-        profile_path: Explicit path to user-profile.yaml. If None, searches
-            ``_PROFILE_SEARCH_PATHS`` for the first existing file.
+        profile_path: Explicit path to user-profile.yaml. If None, uses the
+            profile under the resolved instance root.
         cli_overrides: Dict of CLI flag values. Keys with None values are
             ignored (only non-None values override).
 
@@ -171,12 +164,7 @@ def load_hedge_config(
     config_data: dict = {}
 
     # --- Resolve profile path ---
-    resolved_path = profile_path
-    if resolved_path is None:
-        for candidate in _PROFILE_SEARCH_PATHS:
-            if candidate.exists():
-                resolved_path = candidate
-                break
+    resolved_path = profile_path or InstancePaths.resolve().profile
 
     # --- Load YAML hedging section ---
     if resolved_path is not None and resolved_path.exists():

--- a/src/config/fin_guru_config.py
+++ b/src/config/fin_guru_config.py
@@ -8,7 +8,6 @@ Author: Finance Guru™ Development Team
 Created: 2025-11-17
 """
 
-import os
 from pathlib import Path
 
 import yaml
@@ -21,9 +20,6 @@ class FinGuruConfig:
     """
 
     PROJECT_ROOT = Path(__file__).parent.parent.parent
-    PORTFOLIO_DIR = Path(
-        os.getenv("FIN_GURU_PORTFOLIO_DIR", PROJECT_ROOT / "notebooks" / "updates")
-    )
     CONFIG_DIR = Path.home() / ".config" / "finance-guru"
     LAYERS_FILE = CONFIG_DIR / "layers.yaml"
 

--- a/src/config/instance_paths.py
+++ b/src/config/instance_paths.py
@@ -1,0 +1,141 @@
+"""Resolve every private Finance Guru path from one instance root."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, ConfigDict
+
+
+class InstancePaths(BaseModel):
+    """Every file the engine reads or writes for one family office instance."""
+
+    model_config = ConfigDict(frozen=True)
+
+    root: Path
+
+    @classmethod
+    def resolve(
+        cls,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
+    ) -> InstancePaths:
+        """Resolve an absolute instance root from the environment or cwd."""
+        environment = os.environ if env is None else env
+        working_directory = (cwd or Path.cwd()).expanduser().resolve()
+        configured_root = environment.get("FIN_GURU_DATA_ROOT", "").strip()
+        root = (
+            Path(configured_root).expanduser() if configured_root else working_directory
+        )
+        if not root.is_absolute():
+            root = working_directory / root
+        return cls(root=root.resolve())
+
+    @property
+    def env_file(self) -> Path:
+        """Return the instance environment file."""
+        return self.root / ".env"
+
+    @property
+    def profile(self) -> Path:
+        """Return the user profile path."""
+        return self.root / "user-profile.yaml"
+
+    @property
+    def config(self) -> Path:
+        """Return the instance configuration path."""
+        return self.root / "config.yaml"
+
+    @property
+    def system_context(self) -> Path:
+        """Return the generated system context path."""
+        return self.root / "system-context.md"
+
+    @property
+    def db(self) -> Path:
+        """Return the default family-office database path."""
+        return self.root / "family_office.db"
+
+    @property
+    def imports(self) -> Path:
+        """Return the broker CSV import directory."""
+        return self.root / "imports"
+
+    @property
+    def analysis(self) -> Path:
+        """Return the analysis artifact directory."""
+        return self.root / "analysis"
+
+    @property
+    def tickets(self) -> Path:
+        """Return the buy-ticket directory."""
+        return self.root / "tickets"
+
+    @property
+    def strategies(self) -> Path:
+        """Return the strategy document directory."""
+        return self.root / "strategies"
+
+    @property
+    def hedging(self) -> Path:
+        """Return the hedge position and history directory."""
+        return self.root / "hedging"
+
+    @property
+    def reports(self) -> Path:
+        """Return the report artifact directory."""
+        return self.root / "reports"
+
+    @property
+    def dividend_schedules(self) -> Path:
+        """Return the dividend schedule file path."""
+        return self.root / "dividend-schedules.yaml"
+
+    @property
+    def auto_tickets(self) -> Path:
+        """Return the automated-ticket runtime directory."""
+        return self.root / "auto-tickets"
+
+    def database_url(self, env: Mapping[str, str] | None = None) -> str:
+        """Return the configured database URL with relative paths under root."""
+        environment = os.environ if env is None else env
+        configured_url = environment.get("DATABASE_URL", "").strip()
+        if not configured_url:
+            return _sqlite_url(self.db)
+        if configured_url.startswith("sqlite:///"):
+            database_path = Path(configured_url.removeprefix("sqlite:///"))
+        elif "://" in configured_url:
+            return configured_url
+        else:
+            database_path = Path(configured_url).expanduser()
+        if not database_path.is_absolute():
+            database_path = self.root / database_path
+        return _sqlite_url(database_path.resolve())
+
+
+def _sqlite_url(path: Path) -> str:
+    """Format a filesystem path as a SQLite URL."""
+    return f"sqlite:///{path}"
+
+
+def _db_path(
+    database_url: str | None = None,
+    paths: InstancePaths | None = None,
+) -> Path:
+    """Resolve a SQLite URL or bare path to one absolute filesystem path."""
+    instance_paths = paths or InstancePaths.resolve()
+    environment = None if database_url is None else {"DATABASE_URL": database_url}
+    resolved_url = instance_paths.database_url(environment)
+    if resolved_url.startswith("sqlite:///"):
+        return Path(resolved_url.removeprefix("sqlite:///"))
+    if resolved_url.startswith("sqlite://"):
+        return Path(resolved_url.removeprefix("sqlite://"))
+    return Path(resolved_url)
+
+
+def load_instance_env(paths: InstancePaths, override: bool = True) -> None:
+    """Load the instance's environment file into the process environment."""
+    load_dotenv(paths.env_file, override=override)

--- a/src/config/instance_paths.py
+++ b/src/config/instance_paths.py
@@ -110,6 +110,8 @@ class InstancePaths(BaseModel):
         configured_url = environment.get("DATABASE_URL", "").strip()
         if not configured_url:
             return _sqlite_url(self.db)
+        if configured_url in {":memory:", "sqlite:///:memory:"}:
+            return "sqlite:///:memory:"
         if configured_url.startswith("sqlite:///"):
             database_path = Path(configured_url.removeprefix("sqlite:///"))
         elif "://" in configured_url:
@@ -134,13 +136,18 @@ def _db_path(
     instance_paths = paths or InstancePaths.resolve()
     environment = None if database_url is None else {"DATABASE_URL": database_url}
     resolved_url = instance_paths.database_url(environment)
+    if resolved_url == "sqlite:///:memory:":
+        return Path(":memory:")
     if resolved_url.startswith("sqlite:///"):
         return Path(resolved_url.removeprefix("sqlite:///"))
-    if resolved_url.startswith("sqlite://"):
-        return Path(resolved_url.removeprefix("sqlite://"))
-    return Path(resolved_url)
+    scheme, separator, _ = resolved_url.partition("://")
+    if separator and scheme != "sqlite":
+        raise ValueError(
+            f"Finance Guru only supports sqlite databases, got {scheme}://"
+        )
+    raise ValueError(f"Invalid SQLite database URL: {resolved_url}")
 
 
-def load_instance_env(paths: InstancePaths, override: bool = True) -> None:
+def load_instance_env(paths: InstancePaths, override: bool = False) -> None:
     """Load the instance's environment file into the process environment."""
     load_dotenv(paths.env_file, override=override)

--- a/src/config/instance_paths.py
+++ b/src/config/instance_paths.py
@@ -50,6 +50,11 @@ class InstancePaths(BaseModel):
         return self.root / "config.yaml"
 
     @property
+    def snaptrade_accounts(self) -> Path:
+        """Return the SnapTrade account-routing configuration path."""
+        return self.root / "snaptrade-accounts.yaml"
+
+    @property
     def system_context(self) -> Path:
         """Return the generated system context path."""
         return self.root / "system-context.md"

--- a/src/integrations/refresh_all.py
+++ b/src/integrations/refresh_all.py
@@ -52,7 +52,7 @@ def main(argv: list[str] | None = None) -> int:
         detect a partial refresh where one leg went stale).
     """
     paths = InstancePaths.resolve()
-    load_instance_env(paths)
+    load_instance_env(paths, override=True)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--months", type=int, default=12)
     parser.add_argument("--show", action="store_true")

--- a/src/integrations/refresh_all.py
+++ b/src/integrations/refresh_all.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
 
 from src.config.instance_paths import InstancePaths, load_instance_env
@@ -24,7 +23,7 @@ def refresh(database_url: str | None, *, months: int = 12) -> dict[str, Any]:
     Returns:
         Per-source statuses and the refresh timestamp.
     """
-    account_config = Path("config/snaptrade-accounts.yaml")
+    account_config = InstancePaths.resolve().snaptrade_accounts
     operations: tuple[tuple[str, Callable[[], dict[str, Any]]], ...] = (
         ("positions", lambda: sync_positions(account_config, database_url)),
         ("transactions", lambda: sync_transactions(account_config, database_url)),

--- a/src/integrations/refresh_all.py
+++ b/src/integrations/refresh_all.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import argparse
-import os
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
-
+from src.config.instance_paths import InstancePaths, load_instance_env
 from src.integrations.simplefin.sync_expenses_db import sync as sync_expenses
 from src.integrations.snaptrade.sync_db import sync as sync_positions
 from src.integrations.snaptrade.sync_transactions_db import sync as sync_transactions
@@ -54,12 +52,13 @@ def main(argv: list[str] | None = None) -> int:
         Zero when every source succeeds, otherwise one (so automation can
         detect a partial refresh where one leg went stale).
     """
-    load_dotenv(override=True)
+    paths = InstancePaths.resolve()
+    load_instance_env(paths)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--months", type=int, default=12)
     parser.add_argument("--show", action="store_true")
     args = parser.parse_args(argv)
-    database_url = os.getenv("DATABASE_URL")
+    database_url = paths.database_url()
 
     if args.show:
         from src.integrations.simplefin.sync_expenses_db import show as show_expenses

--- a/src/integrations/simplefin/sync_expenses_db.py
+++ b/src/integrations/simplefin/sync_expenses_db.py
@@ -20,7 +20,7 @@ class SimpleFinSyncError(RuntimeError):
     """Raised when SimpleFIN data cannot be fetched or parsed."""
 
 
-DEFAULT_APP_DIR = Path("apps/simplefin-sync")
+DEFAULT_APP_DIR = Path(__file__).resolve().parents[3] / "apps" / "simplefin-sync"
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS bank_transactions (
@@ -326,7 +326,7 @@ def main(argv: list[str] | None = None) -> int:
         Process exit status.
     """
     paths = InstancePaths.resolve()
-    load_instance_env(paths)
+    load_instance_env(paths, override=True)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--months", type=int, default=12)
     parser.add_argument("--show", action="store_true")

--- a/src/integrations/simplefin/sync_expenses_db.py
+++ b/src/integrations/simplefin/sync_expenses_db.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sqlite3
 import subprocess
 import sys
@@ -13,10 +12,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
-
+from src.config.instance_paths import InstancePaths, _db_path, load_instance_env
 from src.integrations.simplefin.categorize import categorize_expense
-from src.integrations.snaptrade.sync_db import _db_path
 
 
 class SimpleFinSyncError(RuntimeError):
@@ -328,12 +325,13 @@ def main(argv: list[str] | None = None) -> int:
     Returns:
         Process exit status.
     """
-    load_dotenv(override=True)
+    paths = InstancePaths.resolve()
+    load_instance_env(paths)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--months", type=int, default=12)
     parser.add_argument("--show", action="store_true")
     args = parser.parse_args(argv)
-    database_url = os.getenv("DATABASE_URL")
+    database_url = paths.database_url()
 
     if args.show:
         show(database_url)

--- a/src/integrations/snaptrade/cli.py
+++ b/src/integrations/snaptrade/cli.py
@@ -8,9 +8,8 @@ USAGE:
     # Include read-only diagnostics needed before deleting CSV paths
     uv run python -m src.integrations.snaptrade.cli accounts --probe --output json
 
-    # Create local account-routing config for later Sheet sync phases
-    uv run python -m src.integrations.snaptrade.cli accounts \
-        --write-config config/snaptrade-accounts.yaml
+    # Create the instance account-routing config for later sync phases
+    uv run python -m src.integrations.snaptrade.cli accounts --write-config
 
     # Phase 1 — sync positions / balances for config-enabled accounts ONLY.
     # Accounts with role=unassigned or enabled=false are refused, not fetched,
@@ -33,6 +32,7 @@ from typing import Any
 
 import yaml
 
+from src.config.instance_paths import InstancePaths
 from src.integrations.snaptrade.client import (
     SnapTradeAPIError,
     SnapTradeClientWrapper,
@@ -42,8 +42,6 @@ from src.integrations.snaptrade.models import (
     SnapTradeAccountConfig,
     SnapTradeAccountsConfig,
 )
-
-DEFAULT_CONFIG_PATH = Path("config/snaptrade-accounts.yaml")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -82,10 +80,10 @@ def _build_parser() -> argparse.ArgumentParser:
     accounts.add_argument(
         "--write-config",
         nargs="?",
-        const=str(DEFAULT_CONFIG_PATH),
+        const="",
         help=(
             "Write local account routing config. Defaults to "
-            "config/snaptrade-accounts.yaml when no path is supplied."
+            "snaptrade-accounts.yaml under the instance data root."
         ),
     )
     accounts.add_argument(
@@ -107,9 +105,10 @@ def _build_parser() -> argparse.ArgumentParser:
         )
         sub.add_argument(
             "--config",
-            default=str(DEFAULT_CONFIG_PATH),
+            default=None,
             help=(
-                "Account routing config. Defaults to config/snaptrade-accounts.yaml."
+                "Account routing config. Defaults to snaptrade-accounts.yaml "
+                "under the instance data root."
             ),
         )
     return parser
@@ -133,8 +132,12 @@ def _accounts_command(args: argparse.Namespace) -> int:
         if probes:
             payload["probes"] = probes
             payload["phase_0_findings"] = _phase_0_findings(account_payloads, probes)
-        if args.write_config:
-            config_path = Path(args.write_config)
+        if args.write_config is not None:
+            config_path = (
+                Path(args.write_config)
+                if args.write_config
+                else InstancePaths.resolve().snaptrade_accounts
+            )
             _write_config(config_path, accounts, force=args.force)
             payload["config_written"] = str(config_path)
         _print_payload(payload, args.output)
@@ -146,8 +149,13 @@ def _accounts_command(args: argparse.Namespace) -> int:
 
 def _routing_command(args: argparse.Namespace) -> int:
     kind = args.command  # "positions", "balances", or "activities"
+    config_path = (
+        Path(args.config)
+        if args.config is not None
+        else InstancePaths.resolve().snaptrade_accounts
+    )
     try:
-        config = SnapTradeAccountsConfig.from_path(Path(args.config))
+        config = SnapTradeAccountsConfig.from_path(config_path)
     except (FileNotFoundError, ValueError) as exc:
         print(f"SnapTrade config error: {exc}", file=sys.stderr)
         return 1

--- a/src/integrations/snaptrade/models.py
+++ b/src/integrations/snaptrade/models.py
@@ -25,7 +25,7 @@ class SnapTradeCredentials(BaseModel):
     @classmethod
     def from_env(cls) -> Self:
         """Load SnapTrade credentials from the local `.env`/process environment."""
-        load_instance_env(InstancePaths.resolve())
+        load_instance_env(InstancePaths.resolve(), override=False)
         required = {
             "client_id": "SNAPTRADE_CLIENT_ID",
             "consumer_key": "SNAPTRADE_CONSUMER_KEY",

--- a/src/integrations/snaptrade/models.py
+++ b/src/integrations/snaptrade/models.py
@@ -9,8 +9,9 @@ from pathlib import Path
 from typing import Any, Self
 
 import yaml
-from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_serializer
+
+from src.config.instance_paths import InstancePaths, load_instance_env
 
 
 class SnapTradeCredentials(BaseModel):
@@ -24,7 +25,7 @@ class SnapTradeCredentials(BaseModel):
     @classmethod
     def from_env(cls) -> Self:
         """Load SnapTrade credentials from the local `.env`/process environment."""
-        load_dotenv()
+        load_instance_env(InstancePaths.resolve())
         required = {
             "client_id": "SNAPTRADE_CLIENT_ID",
             "consumer_key": "SNAPTRADE_CONSUMER_KEY",

--- a/src/integrations/snaptrade/sync_db.py
+++ b/src/integrations/snaptrade/sync_db.py
@@ -16,7 +16,6 @@ ever wanted, add an append-only `position_history` table keyed on synced_at.
 from __future__ import annotations
 
 import argparse
-import os
 import sqlite3
 import sys
 from collections import defaultdict
@@ -24,8 +23,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
-
+from src.config.instance_paths import InstancePaths, _db_path, load_instance_env
 from src.integrations.snaptrade.cli import _account_balances, _account_positions
 from src.integrations.snaptrade.client import SnapTradeAPIError, SnapTradeClientWrapper
 from src.integrations.snaptrade.models import SnapTradeAccountsConfig
@@ -54,18 +52,6 @@ CREATE TABLE IF NOT EXISTS balances (
     synced_at          TEXT NOT NULL
 );
 """
-
-
-def _db_path(database_url: str | None) -> Path:
-    """Resolve a sqlite:/// URL (or bare path) to a filesystem path."""
-    if not database_url:
-        raise ValueError("DATABASE_URL is not set")
-    if database_url.startswith("sqlite:///"):
-        # sqlite:///rel.db -> rel.db ; sqlite:////abs.db -> /abs.db
-        return Path(database_url[len("sqlite:///") :])
-    if database_url.startswith("sqlite://"):
-        return Path(database_url[len("sqlite://") :])
-    return Path(database_url)
 
 
 def _net_positions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -215,14 +201,15 @@ def show(database_url: str | None) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
-    load_dotenv(override=True)
+    paths = InstancePaths.resolve()
+    load_instance_env(paths)
     parser = argparse.ArgumentParser(description="Sync SnapTrade -> local SQLite DB")
     parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH))
     parser.add_argument(
         "--show", action="store_true", help="Print current snapshot and exit"
     )
     args = parser.parse_args(argv)
-    database_url = os.getenv("DATABASE_URL")
+    database_url = paths.database_url()
     try:
         if args.show:
             show(database_url)

--- a/src/integrations/snaptrade/sync_db.py
+++ b/src/integrations/snaptrade/sync_db.py
@@ -200,7 +200,7 @@ def show(database_url: str | None) -> None:
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
     paths = InstancePaths.resolve()
-    load_instance_env(paths)
+    load_instance_env(paths, override=True)
     parser = argparse.ArgumentParser(description="Sync SnapTrade -> local SQLite DB")
     parser.add_argument(
         "--config",

--- a/src/integrations/snaptrade/sync_db.py
+++ b/src/integrations/snaptrade/sync_db.py
@@ -28,8 +28,6 @@ from src.integrations.snaptrade.cli import _account_balances, _account_positions
 from src.integrations.snaptrade.client import SnapTradeAPIError, SnapTradeClientWrapper
 from src.integrations.snaptrade.models import SnapTradeAccountsConfig
 
-DEFAULT_CONFIG_PATH = Path("config/snaptrade-accounts.yaml")
-
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS positions (
     account_id  TEXT NOT NULL,
@@ -204,17 +202,27 @@ def main(argv: list[str] | None = None) -> int:
     paths = InstancePaths.resolve()
     load_instance_env(paths)
     parser = argparse.ArgumentParser(description="Sync SnapTrade -> local SQLite DB")
-    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH))
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=(
+            "Account routing config. Defaults to snaptrade-accounts.yaml "
+            "under the instance data root."
+        ),
+    )
     parser.add_argument(
         "--show", action="store_true", help="Print current snapshot and exit"
     )
     args = parser.parse_args(argv)
     database_url = paths.database_url()
+    config_path = (
+        Path(args.config) if args.config is not None else paths.snaptrade_accounts
+    )
     try:
         if args.show:
             show(database_url)
             return 0
-        summary = sync(Path(args.config), database_url)
+        summary = sync(config_path, database_url)
     except (SnapTradeAPIError, ValueError, RuntimeError, FileNotFoundError) as exc:
         print(f"Sync error: {exc}", file=sys.stderr)
         return 1

--- a/src/integrations/snaptrade/sync_transactions_db.py
+++ b/src/integrations/snaptrade/sync_transactions_db.py
@@ -147,7 +147,7 @@ def show(database_url: str | None) -> None:
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
     paths = InstancePaths.resolve()
-    load_instance_env(paths)
+    load_instance_env(paths, override=True)
     parser = argparse.ArgumentParser(
         description="Sync SnapTrade activities -> local SQLite DB"
     )

--- a/src/integrations/snaptrade/sync_transactions_db.py
+++ b/src/integrations/snaptrade/sync_transactions_db.py
@@ -31,8 +31,6 @@ from src.config.instance_paths import InstancePaths, _db_path, load_instance_env
 from src.integrations.snaptrade.client import SnapTradeAPIError, SnapTradeClientWrapper
 from src.integrations.snaptrade.models import SnapTradeAccountsConfig
 
-DEFAULT_CONFIG_PATH = Path("config/snaptrade-accounts.yaml")
-
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS transactions (
     account_id  TEXT NOT NULL,
@@ -153,15 +151,25 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Sync SnapTrade activities -> local SQLite DB"
     )
-    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH))
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=(
+            "Account routing config. Defaults to snaptrade-accounts.yaml "
+            "under the instance data root."
+        ),
+    )
     parser.add_argument("--show", action="store_true", help="Print summary and exit")
     args = parser.parse_args(argv)
     database_url = paths.database_url()
+    config_path = (
+        Path(args.config) if args.config is not None else paths.snaptrade_accounts
+    )
     try:
         if args.show:
             show(database_url)
             return 0
-        summary = sync(Path(args.config), database_url)
+        summary = sync(config_path, database_url)
     except (SnapTradeAPIError, ValueError, RuntimeError, FileNotFoundError) as exc:
         print(f"Sync error: {exc}", file=sys.stderr)
         return 1

--- a/src/integrations/snaptrade/sync_transactions_db.py
+++ b/src/integrations/snaptrade/sync_transactions_db.py
@@ -21,18 +21,15 @@ data source appears.
 from __future__ import annotations
 
 import argparse
-import os
 import sqlite3
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
-
+from src.config.instance_paths import InstancePaths, _db_path, load_instance_env
 from src.integrations.snaptrade.client import SnapTradeAPIError, SnapTradeClientWrapper
 from src.integrations.snaptrade.models import SnapTradeAccountsConfig
-from src.integrations.snaptrade.sync_db import _db_path
 
 DEFAULT_CONFIG_PATH = Path("config/snaptrade-accounts.yaml")
 
@@ -151,14 +148,15 @@ def show(database_url: str | None) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
-    load_dotenv(override=True)
+    paths = InstancePaths.resolve()
+    load_instance_env(paths)
     parser = argparse.ArgumentParser(
         description="Sync SnapTrade activities -> local SQLite DB"
     )
     parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH))
     parser.add_argument("--show", action="store_true", help="Print summary and exit")
     args = parser.parse_args(argv)
-    database_url = os.getenv("DATABASE_URL")
+    database_url = paths.database_url()
     try:
         if args.show:
             show(database_url)

--- a/src/ui/services/portfolio_loader.py
+++ b/src/ui/services/portfolio_loader.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from src.config import FinGuruConfig
+from src.config import FinGuruConfig, InstancePaths
 from src.models.dashboard_inputs import HoldingInput, PortfolioSnapshotInput
 
 
@@ -30,7 +30,9 @@ class PortfolioLoader:
         Returns:
             Path to latest CSV file, or None if no files found
         """
-        csv_files = list(FinGuruConfig.PORTFOLIO_DIR.glob("Portfolio_Positions_*.csv"))
+        csv_files = list(
+            InstancePaths.resolve().imports.glob("Portfolio_Positions_*.csv")
+        )
         if not csv_files:
             return None
         return max(csv_files, key=lambda p: p.stat().st_mtime)

--- a/src/ui/widgets/portfolio_header.py
+++ b/src/ui/widgets/portfolio_header.py
@@ -12,6 +12,7 @@ from rich.text import Text
 from textual.reactive import reactive
 from textual.widget import Widget
 
+from src.config import InstancePaths
 from src.models.dashboard_inputs import PortfolioSnapshotInput
 
 
@@ -30,8 +31,9 @@ class PortfolioHeader(Widget):
             Rich Text object with formatted portfolio display
         """
         if not self.portfolio:
+            imports = InstancePaths.resolve().imports
             return Text(
-                "📥 No portfolio data. Add a CSV to the instance imports directory.",
+                f"📥 No portfolio data. Add a CSV to {imports}.",
                 style="dim",
             )
 

--- a/src/ui/widgets/portfolio_header.py
+++ b/src/ui/widgets/portfolio_header.py
@@ -31,7 +31,8 @@ class PortfolioHeader(Widget):
         """
         if not self.portfolio:
             return Text(
-                "📥 No portfolio data - upload CSV to notebooks/updates/", style="dim"
+                "📥 No portfolio data. Add a CSV to the instance imports directory.",
+                style="dim",
             )
 
         p: PortfolioSnapshotInput = self.portfolio

--- a/src/utils/data_validator_cli.py
+++ b/src/utils/data_validator_cli.py
@@ -30,7 +30,7 @@ AGENT USAGE:
 
     # Save report
     uv run python src/utils/data_validator_cli.py TSLA --days 90 \\
-        --save-to fin-guru-private/fin-guru/data-validation-tsla-2025-10-13.json
+        --save-to analysis/data-validation-tsla-2025-10-13.json
 
 EDUCATIONAL NOTE:
 This CLI helps agents verify data quality before analysis.

--- a/src/utils/market_data.py
+++ b/src/utils/market_data.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 
 from src.config.instance_paths import InstancePaths, load_instance_env
 
-load_instance_env(InstancePaths.resolve())
+load_instance_env(InstancePaths.resolve(), override=False)
 
 
 class PriceData(BaseModel):

--- a/src/utils/market_data.py
+++ b/src/utils/market_data.py
@@ -19,11 +19,11 @@ from typing import Any
 
 import requests
 import yfinance as yf
-from dotenv import load_dotenv
 from pydantic import BaseModel
 
-# Load environment variables from .env file
-load_dotenv()
+from src.config.instance_paths import InstancePaths, load_instance_env
+
+load_instance_env(InstancePaths.resolve())
 
 
 class PriceData(BaseModel):

--- a/src/utils/onboarding_sections.py
+++ b/src/utils/onboarding_sections.py
@@ -595,7 +595,9 @@ def run_broker_section(state: OnboardingState) -> OnboardingState:
     print("  two CSV files from your brokerage account:")
     print("    1. Positions CSV (your stock/ETF holdings)")
     print("    2. Balances CSV (cash, margin debt, account totals)")
-    print("  Save these files to: notebooks/updates/")
+    from src.config.instance_paths import InstancePaths
+
+    print(f"  Save these files to: {InstancePaths.resolve().imports}")
     print()
 
     state.data[SectionName.BROKER.value] = {

--- a/src/utils/yaml_generator.py
+++ b/src/utils/yaml_generator.py
@@ -23,6 +23,7 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+from src.config.instance_paths import InstancePaths
 from src.models.yaml_generation_inputs import (
     UserDataInput,
     YAMLGenerationOutput,
@@ -320,16 +321,16 @@ def write_config_files(output: YAMLGenerationOutput, base_dir: str = ".") -> Non
         output: YAMLGenerationOutput with generated content
         base_dir: Base directory for output files (default: current directory)
     """
-    base_path = Path(base_dir)
+    paths = InstancePaths(root=Path(base_dir).expanduser().resolve())
 
     # Define output paths
     files = {
-        base_path / "fin-guru" / "data" / "user-profile.yaml": output.user_profile_yaml,
-        base_path / "fin-guru" / "config.yaml": output.config_yaml,
-        base_path / "fin-guru" / "data" / "system-context.md": output.system_context_md,
-        base_path / "CLAUDE.md": output.claude_md,
-        base_path / ".env": output.env_file,
-        base_path / ".claude" / "mcp.json": output.mcp_json,
+        paths.profile: output.user_profile_yaml,
+        paths.config: output.config_yaml,
+        paths.system_context: output.system_context_md,
+        paths.root / "CLAUDE.md": output.claude_md,
+        paths.env_file: output.env_file,
+        paths.root / ".claude" / "mcp.json": output.mcp_json,
     }
 
     # Write files

--- a/src/utils/yaml_generator_cli.py
+++ b/src/utils/yaml_generator_cli.py
@@ -38,6 +38,7 @@ import json
 import sys
 from pathlib import Path
 
+from src.config.instance_paths import InstancePaths
 from src.models.yaml_generation_inputs import (
     CashFlowInput,
     DebtProfileInput,
@@ -242,18 +243,13 @@ Examples:
                 print(generated_content)
             else:
                 # Write single file
+                paths = InstancePaths(root=Path(args.output).expanduser().resolve())
                 file_map = {
-                    "user-profile": Path(args.output)
-                    / "fin-guru"
-                    / "data"
-                    / "user-profile.yaml",
-                    "config": Path(args.output) / "fin-guru" / "config.yaml",
-                    "system-context": Path(args.output)
-                    / "fin-guru"
-                    / "data"
-                    / "system-context.md",
-                    "claude-md": Path(args.output) / "CLAUDE.md",
-                    "env": Path(args.output) / ".env",
+                    "user-profile": paths.profile,
+                    "config": paths.config,
+                    "system-context": paths.system_context,
+                    "claude-md": paths.root / "CLAUDE.md",
+                    "env": paths.env_file,
                 }
 
                 output_path = file_map[args.type]

--- a/tests/python/test_buy_ticket_agent_smoke.py
+++ b/tests/python/test_buy_ticket_agent_smoke.py
@@ -8,6 +8,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from buy_ticket_agent.config import NotificationConfig
 from buy_ticket_agent.main import main
 from buy_ticket_agent.notifier import NotificationResult, push_ticket_preview
@@ -18,6 +20,12 @@ from buy_ticket_agent.secrets import (
     resolve_notification_config,
 )
 from buy_ticket_agent.state import connect_state, initialize_state, record_smoke_run
+
+
+@pytest.fixture(autouse=True)
+def instance_data_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve buy-ticket artifacts under each test's instance root."""
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
 
 
 def test_initialize_state_is_idempotent(tmp_path: Path) -> None:
@@ -202,7 +210,7 @@ def test_run_smoke_writes_draft_log_and_state(tmp_path: Path, monkeypatch) -> No
         from datetime import UTC, datetime
 
         now.return_value = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
-        result = run_smoke(project_root=tmp_path)
+        result = run_smoke()
 
     draft_path = tmp_path / result.draft_path
     log_path = tmp_path / result.log_path
@@ -226,11 +234,9 @@ def test_run_smoke_writes_draft_log_and_state(tmp_path: Path, monkeypatch) -> No
     assert log["layer3"]["stderr_chars"] == len(completed.stderr)
     assert "stdout" not in log["layer3"]
     assert "stderr" not in log["layer3"]
-    assert result.draft_path == (
-        f"fin-guru-private/fin-guru/tickets/auto-drafts/{result.run_id}.json"
-    )
-    assert result.log_path.startswith("notebooks/auto-tickets/runs/smoke-20260605-")
-    assert result.state_db == "notebooks/auto-tickets/state.db"
+    assert result.draft_path == f"tickets/auto-drafts/{result.run_id}.json"
+    assert result.log_path.startswith("auto-tickets/runs/smoke-20260605-")
+    assert result.state_db == "auto-tickets/state.db"
 
     command = run.call_args.args[0]
     assert command[1:] == [
@@ -270,7 +276,7 @@ def test_run_smoke_includes_sanitized_trigger_context(
     completed.stderr = ""
 
     with patch("buy_ticket_agent.pipeline.subprocess.run", return_value=completed):
-        result = run_smoke(project_root=tmp_path)
+        result = run_smoke()
 
     draft = json.loads((tmp_path / result.draft_path).read_text())
     log = json.loads((tmp_path / result.log_path).read_text())
@@ -312,13 +318,13 @@ def test_run_smoke_does_not_record_success_state_if_log_write_fails(
         ),
     ):
         try:
-            run_smoke(project_root=tmp_path)
+            run_smoke()
         except OSError:
             pass
         else:
             raise AssertionError("Expected log write failure")
 
-    state_db = tmp_path / "notebooks" / "auto-tickets" / "state.db"
+    state_db = tmp_path / "auto-tickets" / "state.db"
     with sqlite3.connect(state_db) as conn:
         counts = (
             conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0],
@@ -373,7 +379,7 @@ def test_run_smoke_layer3_failure_records_failure_without_draft(
         from datetime import UTC, datetime
 
         now.return_value = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
-        result = run_smoke(project_root=tmp_path)
+        result = run_smoke()
 
     log_path = tmp_path / result.log_path
     state_db = tmp_path / result.state_db
@@ -384,9 +390,7 @@ def test_run_smoke_layer3_failure_records_failure_without_draft(
     assert result.ticket_id is None
     assert result.draft_path is None
     assert result.notification is None
-    assert not (
-        tmp_path / "fin-guru-private" / "fin-guru" / "tickets" / "auto-drafts"
-    ).exists()
+    assert not (tmp_path / "tickets" / "auto-drafts").exists()
     assert log["layer3"]["returncode"] == 2
     assert log["layer3"]["stdout_chars"] == len(completed.stdout)
     assert log["layer3"]["stderr_chars"] == len(completed.stderr)
@@ -424,13 +428,13 @@ def test_run_smoke_does_not_record_failure_state_if_log_write_fails(
         ),
     ):
         try:
-            run_smoke(project_root=tmp_path)
+            run_smoke()
         except OSError:
             pass
         else:
             raise AssertionError("Expected log write failure")
 
-    state_db = tmp_path / "notebooks" / "auto-tickets" / "state.db"
+    state_db = tmp_path / "auto-tickets" / "state.db"
     with sqlite3.connect(state_db) as conn:
         counts = (
             conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0],
@@ -468,17 +472,15 @@ def test_run_smoke_secret_failure_leaves_no_partial_artifacts(tmp_path: Path) ->
         side_effect=SecretAccessError("bws unavailable"),
     ):
         try:
-            run_smoke(project_root=tmp_path)
+            run_smoke()
         except SecretAccessError:
             pass
         else:
             raise AssertionError("Expected SecretAccessError")
 
-    assert not (
-        tmp_path / "fin-guru-private" / "fin-guru" / "tickets" / "auto-drafts"
-    ).exists()
-    assert not (tmp_path / "notebooks" / "auto-tickets" / "state.db").exists()
-    assert not (tmp_path / "notebooks" / "auto-tickets" / "runs").exists()
+    assert not (tmp_path / "tickets" / "auto-drafts").exists()
+    assert not (tmp_path / "auto-tickets" / "state.db").exists()
+    assert not (tmp_path / "auto-tickets" / "runs").exists()
 
 
 def test_main_smoke_exits_zero(tmp_path: Path) -> None:

--- a/tests/python/test_config_loader.py
+++ b/tests/python/test_config_loader.py
@@ -131,6 +131,16 @@ class TestLoadHedgeConfig:
         assert config.monthly_budget == 500.0
         assert config.roll_window_days == 7
 
+    def test_uses_profile_from_instance_data_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_profile(tmp_path, {"monthly_budget": 1234})
+        monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+
+        config = load_hedge_config()
+
+        assert config.monthly_budget == 1234.0
+
     def test_loads_from_yaml(self, tmp_path: Path):
         """YAML hedging section values should override defaults."""
         path = _write_profile(tmp_path, {"monthly_budget": 800})

--- a/tests/python/test_hedge_sizer.py
+++ b/tests/python/test_hedge_sizer.py
@@ -31,6 +31,16 @@ from src.analysis.hedge_sizer import (
 )
 from src.config.config_loader import HedgeConfig
 
+
+@pytest.fixture
+def imports_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Return the broker-import directory for an isolated instance root."""
+    path = tmp_path / "imports"
+    path.mkdir()
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+    return path
+
+
 # ---------------------------------------------------------------------------
 # calculate_contract_count
 # ---------------------------------------------------------------------------
@@ -147,66 +157,56 @@ class TestAllocateContracts:
 class TestReadPortfolioValueFromCSV:
     """Test Fidelity CSV parsing."""
 
-    def test_reads_actual_csv_format(self, tmp_path: Path) -> None:
+    def test_reads_actual_csv_format(self, imports_dir: Path) -> None:
         """Parse real Fidelity balance CSV format."""
         csv_content = textwrap.dedent("""\
             ,Balance,Day change
             Total account value,202688.46,-764.66
             Account equity percentage,85.51%,
         """)
-        csv_file = tmp_path / "Balances_for_Account_Z12345.csv"
+        csv_file = imports_dir / "Balances_for_Account_TEST.csv"
         csv_file.write_text(csv_content)
 
-        glob_pattern = str(tmp_path / "Balances_for_Account_*.csv")
-        with patch("src.analysis.hedge_sizer.BALANCES_GLOB", glob_pattern):
-            result = read_portfolio_value_from_csv()
+        result = read_portfolio_value_from_csv()
 
         assert result == pytest.approx(202688.46)
 
-    def test_returns_none_when_no_files(self, tmp_path: Path) -> None:
+    def test_returns_none_when_no_files(self, imports_dir: Path) -> None:
         """Returns None when no balance CSV exists."""
-        glob_pattern = str(tmp_path / "Balances_for_Account_*.csv")
-        with patch("src.analysis.hedge_sizer.BALANCES_GLOB", glob_pattern):
-            result = read_portfolio_value_from_csv()
+        result = read_portfolio_value_from_csv()
 
         assert result is None
 
-    def test_returns_none_on_missing_row(self, tmp_path: Path) -> None:
+    def test_returns_none_on_missing_row(self, imports_dir: Path) -> None:
         """Returns None when CSV lacks 'Total account value' row."""
         csv_content = ",Balance,Day change\nSome other row,100,0\n"
-        csv_file = tmp_path / "Balances_for_Account_Z99999.csv"
+        csv_file = imports_dir / "Balances_for_Account_TEST.csv"
         csv_file.write_text(csv_content)
 
-        glob_pattern = str(tmp_path / "Balances_for_Account_*.csv")
-        with patch("src.analysis.hedge_sizer.BALANCES_GLOB", glob_pattern):
-            result = read_portfolio_value_from_csv()
+        result = read_portfolio_value_from_csv()
 
         assert result is None
 
-    def test_handles_dollar_sign_and_commas(self, tmp_path: Path) -> None:
+    def test_handles_dollar_sign_and_commas(self, imports_dir: Path) -> None:
         """Parse values with $ and comma formatting."""
         csv_content = ",Balance,Day change\nTotal account value,$1,234,567.89,0\n"
-        csv_file = tmp_path / "Balances_for_Account_Z00001.csv"
+        csv_file = imports_dir / "Balances_for_Account_TEST.csv"
         csv_file.write_text(csv_content)
 
-        glob_pattern = str(tmp_path / "Balances_for_Account_*.csv")
-        with patch("src.analysis.hedge_sizer.BALANCES_GLOB", glob_pattern):
-            result = read_portfolio_value_from_csv()
+        result = read_portfolio_value_from_csv()
 
         # With commas in the value and splitting by comma, the parsing
         # extracts the first part after the label -- "$1" -> 1.0
         # This is expected behavior for the current CSV format (no commas in value)
         assert result is not None
 
-    def test_case_insensitive_match(self, tmp_path: Path) -> None:
+    def test_case_insensitive_match(self, imports_dir: Path) -> None:
         """Match 'total account value' regardless of case."""
         csv_content = ",Balance\ntotal ACCOUNT Value,500000.00,0\n"
-        csv_file = tmp_path / "Balances_for_Account_Z11111.csv"
+        csv_file = imports_dir / "Balances_for_Account_TEST.csv"
         csv_file.write_text(csv_content)
 
-        glob_pattern = str(tmp_path / "Balances_for_Account_*.csv")
-        with patch("src.analysis.hedge_sizer.BALANCES_GLOB", glob_pattern):
-            result = read_portfolio_value_from_csv()
+        result = read_portfolio_value_from_csv()
 
         assert result == pytest.approx(500000.00)
 
@@ -592,21 +592,11 @@ class TestHedgeSizerCLI:
         assert "disclaimer" in data
 
 
-class TestEnvVarOverrides:
-    """Verify module-level path constants honor their env var overrides."""
+class TestInstanceDataRoot:
+    """Verify CSV discovery follows the resolved instance root."""
 
-    def test_portfolio_dir_env_var_shifts_balances_glob(self, monkeypatch, tmp_path):
-        import importlib
+    def test_data_root_selects_import_directory(self, imports_dir: Path) -> None:
+        csv_path = imports_dir / "Balances_for_Account_SYNTH.csv"
+        csv_path.write_text("Total account value,123456.00,0\n")
 
-        from src.analysis import hedge_sizer
-
-        monkeypatch.setenv("FIN_GURU_PORTFOLIO_DIR", str(tmp_path))
-        reloaded = importlib.reload(hedge_sizer)
-        try:
-            assert tmp_path == reloaded.PORTFOLIO_DIR
-            assert (
-                str(tmp_path / "Balances_for_Account_*.csv") == reloaded.BALANCES_GLOB
-            )
-        finally:
-            monkeypatch.delenv("FIN_GURU_PORTFOLIO_DIR")
-            importlib.reload(hedge_sizer)
+        assert read_portfolio_value_from_csv() == pytest.approx(123456.0)

--- a/tests/python/test_instance_paths.py
+++ b/tests/python/test_instance_paths.py
@@ -1,0 +1,65 @@
+"""Tests for the instance data-root model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.config import InstancePaths
+
+
+def test_default_root_is_current_working_directory(tmp_path: Path) -> None:
+    paths = InstancePaths.resolve(env={}, cwd=tmp_path)
+
+    assert paths.root == tmp_path.resolve()
+
+
+def test_data_root_environment_variable_wins(tmp_path: Path) -> None:
+    cwd = tmp_path / "cwd"
+    root = tmp_path / "instance"
+
+    paths = InstancePaths.resolve(
+        env={"FIN_GURU_DATA_ROOT": str(root)},
+        cwd=cwd,
+    )
+
+    assert paths.root == root.resolve()
+
+
+def test_relative_data_root_becomes_absolute(tmp_path: Path) -> None:
+    paths = InstancePaths.resolve(
+        env={"FIN_GURU_DATA_ROOT": "instance"},
+        cwd=tmp_path,
+    )
+
+    assert paths.root == (tmp_path / "instance").resolve()
+    assert paths.root.is_absolute()
+
+
+def test_database_url_defaults_to_database_under_root(tmp_path: Path) -> None:
+    paths = InstancePaths(root=tmp_path)
+
+    assert paths.database_url(env={}) == f"sqlite:///{tmp_path / 'family_office.db'}"
+
+
+def test_relative_sqlite_database_url_resolves_under_root(tmp_path: Path) -> None:
+    paths = InstancePaths(root=tmp_path)
+
+    assert paths.database_url(env={"DATABASE_URL": "sqlite:///relative.db"}) == (
+        f"sqlite:///{tmp_path / 'relative.db'}"
+    )
+
+
+def test_absolute_sqlite_database_url_is_preserved(tmp_path: Path) -> None:
+    paths = InstancePaths(root=tmp_path)
+
+    assert paths.database_url(env={"DATABASE_URL": "sqlite:////abs.db"}) == (
+        "sqlite:////abs.db"
+    )
+
+
+def test_bare_database_path_resolves_under_root(tmp_path: Path) -> None:
+    paths = InstancePaths(root=tmp_path)
+
+    assert paths.database_url(env={"DATABASE_URL": "relative.db"}) == (
+        f"sqlite:///{tmp_path / 'relative.db'}"
+    )

--- a/tests/python/test_instance_paths.py
+++ b/tests/python/test_instance_paths.py
@@ -63,3 +63,9 @@ def test_bare_database_path_resolves_under_root(tmp_path: Path) -> None:
     assert paths.database_url(env={"DATABASE_URL": "relative.db"}) == (
         f"sqlite:///{tmp_path / 'relative.db'}"
     )
+
+
+def test_snaptrade_accounts_file_is_under_instance_root(tmp_path: Path) -> None:
+    paths = InstancePaths(root=tmp_path)
+
+    assert paths.snaptrade_accounts == tmp_path / "snaptrade-accounts.yaml"

--- a/tests/python/test_instance_paths.py
+++ b/tests/python/test_instance_paths.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
+import pytest
+
 from src.config import InstancePaths
+from src.config.instance_paths import _db_path, load_instance_env
 
 
 def test_default_root_is_current_working_directory(tmp_path: Path) -> None:
@@ -63,6 +67,42 @@ def test_bare_database_path_resolves_under_root(tmp_path: Path) -> None:
     assert paths.database_url(env={"DATABASE_URL": "relative.db"}) == (
         f"sqlite:///{tmp_path / 'relative.db'}"
     )
+
+
+@pytest.mark.parametrize("configured_url", ["sqlite:///:memory:", ":memory:"])
+def test_memory_database_url_is_preserved(configured_url: str, tmp_path: Path) -> None:
+    paths = InstancePaths(root=tmp_path)
+
+    assert paths.database_url(env={"DATABASE_URL": configured_url}) == (
+        "sqlite:///:memory:"
+    )
+    assert _db_path(configured_url, paths) == Path(":memory:")
+
+
+def test_db_path_rejects_non_sqlite_urls(tmp_path: Path) -> None:
+    paths = InstancePaths(root=tmp_path)
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Finance Guru only supports sqlite databases, got postgresql://$",
+    ):
+        _db_path("postgresql://database.example/finance", paths)
+
+
+def test_load_instance_env_preserves_process_values_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = InstancePaths(root=tmp_path)
+    paths.env_file.write_text("DATABASE_URL=sqlite:///instance.db\n", encoding="utf-8")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///process.db")
+
+    load_instance_env(paths)
+
+    assert os.environ["DATABASE_URL"] == "sqlite:///process.db"
+
+    load_instance_env(paths, override=True)
+
+    assert os.environ["DATABASE_URL"] == "sqlite:///instance.db"
 
 
 def test_snaptrade_accounts_file_is_under_instance_root(tmp_path: Path) -> None:

--- a/tests/python/test_margin_metrics.py
+++ b/tests/python/test_margin_metrics.py
@@ -91,14 +91,16 @@ def test_calculate_margin_metrics_derives_values_from_live_balances(tmp_path):
 
 
 def test_metrics_from_runtime_uses_latest_csv_and_env_config(tmp_path, monkeypatch):
-    older = tmp_path / "Balances_for_Account_OLD.csv"
-    newer = tmp_path / "Balances_for_Account_NEW.csv"
+    imports_dir = tmp_path / "imports"
+    imports_dir.mkdir()
+    older = imports_dir / "Balances_for_Account_OLD.csv"
+    newer = imports_dir / "Balances_for_Account_NEW.csv"
     write_balances(older)
     write_balances(newer)
     os.utime(older, (1, 1))
     os.utime(newer, (2, 2))
 
-    monkeypatch.setenv("FIN_GURU_PORTFOLIO_DIR", str(tmp_path))
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
     monkeypatch.setenv("FG_MARGIN_INTEREST_RATE_DECIMAL", "0.12")
     monkeypatch.setenv("FG_MARGIN_JUMP_ALERT_THRESHOLD", "$5,000")
     monkeypatch.setenv("FG_DIVIDEND_MONTHLY_INCOME", "$250")

--- a/tests/python/test_no_hardcoded_references.py
+++ b/tests/python/test_no_hardcoded_references.py
@@ -25,7 +25,7 @@ ALLOWED_FILES = {
     "fin-guru/distribution-plan.md",  # Distribution planning doc
     "fin-guru/tasks/",  # Task files with examples
     "specs/archive/",  # Archived specs
-    "fin-guru-private/",  # Private data directory (not distributed)
+    "fin-guru-private/",  # Legacy private data directory (gitignored, not distributed)
     "notebooks/",  # Private notebooks (not distributed)
     "docs/onboarding-flow-evaluation.md",  # Evaluation document referencing the owner's setup
     "Plans/",  # Session plans (gitignored, not distributed)

--- a/tests/python/test_onboarding_wizard.py
+++ b/tests/python/test_onboarding_wizard.py
@@ -284,8 +284,10 @@ class TestConvertStateToUserData:
 class TestGenerateConfigFiles:
     """Test config file generation to correct paths."""
 
-    def test_generates_all_files(self, valid_user_data, tmp_path):
+    def test_generates_all_files(self, valid_user_data, tmp_path, monkeypatch):
         """All config files are created at correct locations."""
+        monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+
         # Copy templates to tmp_path so we can use it as project root
         import shutil
 
@@ -312,8 +314,12 @@ class TestGenerateConfigFiles:
         assert (tmp_path / ".env").exists()
         assert (tmp_path / ".claude" / "mcp.json").exists()
 
-    def test_generated_files_contain_user_name(self, valid_user_data, tmp_path):
+    def test_generated_files_contain_user_name(
+        self, valid_user_data, tmp_path, monkeypatch
+    ):
         """Generated files contain actual user name, not template placeholders."""
+        monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+
         import shutil
 
         template_src = Path("scripts/onboarding/modules/templates")

--- a/tests/python/test_onboarding_wizard.py
+++ b/tests/python/test_onboarding_wizard.py
@@ -302,14 +302,10 @@ class TestGenerateConfigFiles:
         valid_user_data.project_root = str(tmp_path)
         generate_config_files(valid_user_data, tmp_path)
 
-        # Verify private files
-        assert (
-            tmp_path / "fin-guru-private" / "fin-guru" / "data" / "user-profile.yaml"
-        ).exists()
-        assert (tmp_path / "fin-guru-private" / "fin-guru" / "config.yaml").exists()
-        assert (
-            tmp_path / "fin-guru-private" / "fin-guru" / "data" / "system-context.md"
-        ).exists()
+        # Verify instance files
+        assert (tmp_path / "user-profile.yaml").exists()
+        assert (tmp_path / "config.yaml").exists()
+        assert (tmp_path / "system-context.md").exists()
 
         # Verify project-root files
         assert (tmp_path / "CLAUDE.md").exists()
@@ -331,9 +327,7 @@ class TestGenerateConfigFiles:
         valid_user_data.project_root = str(tmp_path)
         generate_config_files(valid_user_data, tmp_path)
 
-        profile = (
-            tmp_path / "fin-guru-private" / "fin-guru" / "data" / "user-profile.yaml"
-        ).read_text()
+        profile = (tmp_path / "user-profile.yaml").read_text()
         assert "TestUser" in profile
         assert "{{user_name}}" not in profile
 

--- a/tests/python/test_portfolio_header.py
+++ b/tests/python/test_portfolio_header.py
@@ -1,0 +1,17 @@
+"""Tests for the portfolio summary header."""
+
+from pathlib import Path
+
+import pytest
+
+from src.ui.widgets.portfolio_header import PortfolioHeader
+
+
+def test_empty_portfolio_names_resolved_imports_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+
+    message = PortfolioHeader().render().plain
+
+    assert str(tmp_path / "imports") in message

--- a/tests/python/test_rolling_tracker.py
+++ b/tests/python/test_rolling_tracker.py
@@ -9,7 +9,6 @@ interfaces work end-to-end.
 
 from __future__ import annotations
 
-import importlib
 import json
 import subprocess
 import sys
@@ -20,7 +19,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from src.analysis import rolling_tracker
 from src.analysis.rolling_tracker import (
     RollingTracker,
     _dte_status,
@@ -33,6 +31,16 @@ from src.analysis.rolling_tracker import (
 )
 from src.config.config_loader import HedgeConfig
 from src.models.hedging_inputs import HedgePosition
+
+
+@pytest.fixture
+def hedging_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Return the hedging directory for an isolated instance root."""
+    path = tmp_path / "hedging"
+    path.mkdir()
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+    return path
+
 
 # ---------------------------------------------------------------------------
 # price_american_put
@@ -178,24 +186,24 @@ class TestRankContractScore:
 class TestPositionPersistence:
     """Tests for position YAML load/save round-trip."""
 
-    def test_load_empty_file(self, tmp_path: Path):
+    def test_load_empty_file(self, hedging_dir: Path):
         """Empty positions file should return empty list."""
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text("positions: []\n")
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = load_positions()
         assert result == []
 
-    def test_load_nonexistent_file(self, tmp_path: Path):
+    def test_load_nonexistent_file(self, hedging_dir: Path):
         """Missing positions file should return empty list."""
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = load_positions()
         assert result == []
 
-    def test_load_valid_position(self, tmp_path: Path):
+    def test_load_valid_position(self, hedging_dir: Path):
         """Valid position entry should parse correctly."""
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         data = {
             "positions": [
                 {
@@ -212,15 +220,15 @@ class TestPositionPersistence:
         }
         positions_file.write_text(yaml.dump(data))
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = load_positions()
         assert len(result) == 1
         assert result[0].ticker == "QQQ"
         assert result[0].strike == 420.0
 
-    def test_load_skips_invalid_entry(self, tmp_path: Path):
+    def test_load_skips_invalid_entry(self, hedging_dir: Path):
         """Invalid entries should be skipped with warning."""
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         data = {
             "positions": [
                 {"ticker": "QQQ", "hedge_type": "put"},  # missing required fields
@@ -237,12 +245,12 @@ class TestPositionPersistence:
         }
         positions_file.write_text(yaml.dump(data))
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = load_positions()
         assert len(result) == 1
         assert result[0].ticker == "SPY"
 
-    def test_save_and_reload(self, tmp_path: Path):
+    def test_save_and_reload(self, hedging_dir: Path):
         """Saved positions should round-trip through YAML."""
         pos = HedgePosition(
             ticker="QQQ",
@@ -254,7 +262,7 @@ class TestPositionPersistence:
             entry_date=date(2026, 2, 1),
         )
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             save_positions([pos])
             reloaded = load_positions()
 
@@ -263,12 +271,12 @@ class TestPositionPersistence:
         assert reloaded[0].strike == 420.0
         assert reloaded[0].quantity == 2
 
-    def test_load_yaml_none_safety(self, tmp_path: Path):
+    def test_load_yaml_none_safety(self, hedging_dir: Path):
         """Empty YAML file (None from safe_load) should return empty list."""
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text("")
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = load_positions()
         assert result == []
 
@@ -281,22 +289,22 @@ class TestPositionPersistence:
 class TestRollHistoryPersistence:
     """Tests for roll history YAML load/save."""
 
-    def test_load_empty_history(self, tmp_path: Path):
+    def test_load_empty_history(self, hedging_dir: Path):
         """Empty roll history should return empty list."""
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = load_roll_history()
         assert result == []
 
-    def test_load_nonexistent_history(self, tmp_path: Path):
+    def test_load_nonexistent_history(self, hedging_dir: Path):
         """Missing history file should return empty list."""
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = load_roll_history()
         assert result == []
 
-    def test_save_and_reload_history(self, tmp_path: Path):
+    def test_save_and_reload_history(self, hedging_dir: Path):
         """Saved history should round-trip correctly."""
         record = {
             "roll_date": "2026-02-01",
@@ -304,7 +312,7 @@ class TestRollHistoryPersistence:
             "reason": "rolled",
         }
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             save_roll_history([record])
             result = load_roll_history()
 
@@ -320,17 +328,17 @@ class TestRollHistoryPersistence:
 class TestRollingTrackerGetStatus:
     """Tests for RollingTracker.get_status method."""
 
-    def test_empty_positions(self, tmp_path: Path):
+    def test_empty_positions(self, hedging_dir: Path):
         """Status with no positions should return empty lists."""
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text("positions: []\n")
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             status = tracker.get_status()
 
         assert status["positions"] == []
@@ -338,7 +346,7 @@ class TestRollingTrackerGetStatus:
         assert status["summary"]["total_hedge_cost"] == 0.0
         assert status["summary"]["total_pnl"] == 0.0
 
-    def test_auto_archives_expired(self, tmp_path: Path):
+    def test_auto_archives_expired(self, hedging_dir: Path):
         """Expired positions should be moved to roll history."""
         yesterday = date.today() - timedelta(days=1)
         data = {
@@ -354,27 +362,27 @@ class TestRollingTrackerGetStatus:
                 }
             ]
         }
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text(yaml.dump(data))
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             status = tracker.get_status()
 
         # Position should be archived
         assert status["summary"]["position_count"] == 0
 
         # Check roll history was updated
-        with open(tmp_path / "roll-history.yaml") as f:
+        with open(hedging_dir / "roll-history.yaml") as f:
             history_data = yaml.safe_load(f)
         assert len(history_data["rolls"]) == 1
         assert history_data["rolls"][0]["reason"] == "expired"
 
-    def test_enriches_put_position(self, tmp_path: Path):
+    def test_enriches_put_position(self, hedging_dir: Path):
         """Active put position should be enriched with pricing and DTE."""
         future_date = date.today() + timedelta(days=30)
         data = {
@@ -391,9 +399,9 @@ class TestRollingTrackerGetStatus:
                 }
             ]
         }
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text(yaml.dump(data))
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
         # Mock get_prices to return a known spot price
@@ -404,7 +412,7 @@ class TestRollingTrackerGetStatus:
         tracker = RollingTracker(config)
 
         with (
-            patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path),
+            patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}),
             patch(
                 "src.analysis.rolling_tracker.get_prices",
                 return_value={"QQQ": mock_price},
@@ -420,7 +428,7 @@ class TestRollingTrackerGetStatus:
         assert pos["dte_color"] == "green"
         assert pos["quantity"] == 2
 
-    def test_pricing_error_fallback(self, tmp_path: Path):
+    def test_pricing_error_fallback(self, hedging_dir: Path):
         """Pricing error should fall back to entry cost with error flag."""
         future_date = date.today() + timedelta(days=30)
         data = {
@@ -436,16 +444,16 @@ class TestRollingTrackerGetStatus:
                 }
             ]
         }
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text(yaml.dump(data))
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
         with (
-            patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path),
+            patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}),
             patch(
                 "src.analysis.rolling_tracker.get_prices",
                 side_effect=Exception("API error"),
@@ -467,7 +475,7 @@ class TestRollingTrackerGetStatus:
 class TestRollingTrackerLogRoll:
     """Tests for RollingTracker.log_roll method."""
 
-    def test_roll_creates_new_position(self, tmp_path: Path):
+    def test_roll_creates_new_position(self, hedging_dir: Path):
         """Logging a roll should archive old and create new position."""
         future_date = date.today() + timedelta(days=5)
         new_expiry = date.today() + timedelta(days=75)
@@ -485,15 +493,15 @@ class TestRollingTrackerLogRoll:
                 }
             ]
         }
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text(yaml.dump(data))
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = tracker.log_roll("QQQ", 430.0, new_expiry, 9.00)
 
         assert result["old_position"]["strike"] == 420.0
@@ -501,28 +509,28 @@ class TestRollingTrackerLogRoll:
         assert result["new_position"]["quantity"] == 2  # inherited
 
         # Check files updated
-        with open(tmp_path / "positions.yaml") as f:
+        with open(hedging_dir / "positions.yaml") as f:
             pos_data = yaml.safe_load(f)
         assert len(pos_data["positions"]) == 1
         assert pos_data["positions"][0]["strike"] == 430.0
 
-        with open(tmp_path / "roll-history.yaml") as f:
+        with open(hedging_dir / "roll-history.yaml") as f:
             hist_data = yaml.safe_load(f)
         assert len(hist_data["rolls"]) == 1
         assert hist_data["rolls"][0]["reason"] == "rolled"
 
-    def test_roll_nonexistent_ticker_raises(self, tmp_path: Path):
+    def test_roll_nonexistent_ticker_raises(self, hedging_dir: Path):
         """Rolling a ticker not in positions should raise ValueError."""
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text("positions: []\n")
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
         with (
-            patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path),
+            patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}),
             pytest.raises(ValueError, match="No active put position"),
         ):
             tracker.log_roll("QQQ", 430.0, date.today() + timedelta(days=75), 9.00)
@@ -536,19 +544,19 @@ class TestRollingTrackerLogRoll:
 class TestRollingTrackerGetHistory:
     """Tests for RollingTracker.get_history method."""
 
-    def test_empty_history(self, tmp_path: Path):
+    def test_empty_history(self, hedging_dir: Path):
         """Empty history file should return empty list."""
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = tracker.get_history()
         assert result == []
 
-    def test_returns_history_records(self, tmp_path: Path):
+    def test_returns_history_records(self, hedging_dir: Path):
         """History with records should be returned."""
         data = {
             "rolls": [
@@ -559,13 +567,13 @@ class TestRollingTrackerGetHistory:
                 },
             ]
         }
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text(yaml.dump(data))
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = tracker.get_history()
         assert len(result) == 1
         assert result[0]["reason"] == "rolled"
@@ -579,19 +587,19 @@ class TestRollingTrackerGetHistory:
 class TestRollingTrackerSuggestRolls:
     """Tests for RollingTracker.suggest_rolls method."""
 
-    def test_no_positions_returns_empty(self, tmp_path: Path):
+    def test_no_positions_returns_empty(self, hedging_dir: Path):
         """No positions should return empty suggestions list."""
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text("positions: []\n")
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = tracker.suggest_rolls()
         assert result == []
 
-    def test_non_expiring_positions_skipped(self, tmp_path: Path):
+    def test_non_expiring_positions_skipped(self, hedging_dir: Path):
         """Positions with DTE > 7 should not generate suggestions."""
         future_date = date.today() + timedelta(days=30)
         data = {
@@ -607,17 +615,17 @@ class TestRollingTrackerSuggestRolls:
                 }
             ]
         }
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text(yaml.dump(data))
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = tracker.suggest_rolls()
         assert result == []
 
-    def test_inverse_etf_positions_skipped(self, tmp_path: Path):
+    def test_inverse_etf_positions_skipped(self, hedging_dir: Path):
         """Inverse ETF positions should not generate roll suggestions."""
         data = {
             "positions": [
@@ -630,17 +638,17 @@ class TestRollingTrackerSuggestRolls:
                 }
             ]
         }
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text(yaml.dump(data))
 
         config = HedgeConfig()
         tracker = RollingTracker(config)
 
-        with patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path):
+        with patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}):
             result = tracker.suggest_rolls()
         assert result == []
 
-    def test_expiring_position_generates_suggestion(self, tmp_path: Path):
+    def test_expiring_position_generates_suggestion(self, hedging_dir: Path):
         """Position with DTE <= 7 should generate a roll suggestion."""
         expiry_soon = date.today() + timedelta(days=5)
         data = {
@@ -657,7 +665,7 @@ class TestRollingTrackerSuggestRolls:
                 }
             ]
         }
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text(yaml.dump(data))
 
         # Mock get_prices for remaining value calculation
@@ -686,7 +694,7 @@ class TestRollingTrackerSuggestRolls:
         tracker = RollingTracker(config)
 
         with (
-            patch("src.analysis.rolling_tracker.HEDGING_DIR", tmp_path),
+            patch.dict("os.environ", {"FIN_GURU_DATA_ROOT": str(hedging_dir.parent)}),
             patch(
                 "src.analysis.rolling_tracker.get_prices",
                 return_value={"QQQ": mock_price},
@@ -727,12 +735,12 @@ class TestRollingTrackerCLI:
         assert "status" in result.stdout
         assert "suggest-roll" in result.stdout
 
-    def test_cli_status_json(self, tmp_path: Path):
+    def test_cli_status_json(self, hedging_dir: Path):
         """status --output json exits 0 and returns valid JSON."""
         # Create empty positions and history files so status returns cleanly
-        positions_file = tmp_path / "positions.yaml"
+        positions_file = hedging_dir / "positions.yaml"
         positions_file.write_text("positions: []\n")
-        history_file = tmp_path / "roll-history.yaml"
+        history_file = hedging_dir / "roll-history.yaml"
         history_file.write_text("rolls: []\n")
 
         result = subprocess.run(
@@ -748,7 +756,7 @@ class TestRollingTrackerCLI:
             cwd=str(Path(__file__).parent.parent.parent),
             env={
                 **__import__("os").environ,
-                "FIN_GURU_HEDGING_DIR": str(tmp_path),
+                "FIN_GURU_DATA_ROOT": str(hedging_dir.parent),
             },
         )
         # The CLI may fail if config file is missing, but if it succeeds
@@ -759,25 +767,10 @@ class TestRollingTrackerCLI:
             assert "positions" in data or "summary" in data
 
 
-class TestEnvVarOverrides:
-    """Verify module-level path constants honor their env var overrides."""
+class TestInstanceDataRoot:
+    """Verify persistence follows the resolved instance root."""
 
-    def test_private_dir_env_var_shifts_hedging_default(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("FIN_GURU_PRIVATE_DIR", str(tmp_path))
-        reloaded = importlib.reload(rolling_tracker)
-        try:
-            assert tmp_path == reloaded.PRIVATE_DIR
-            assert tmp_path / "hedging" == reloaded.HEDGING_DIR
-        finally:
-            monkeypatch.delenv("FIN_GURU_PRIVATE_DIR")
-            importlib.reload(rolling_tracker)
+    def test_data_root_selects_hedging_directory(self, hedging_dir: Path) -> None:
+        save_positions([])
 
-    def test_hedging_dir_env_var_takes_precedence(self, monkeypatch, tmp_path):
-        explicit = tmp_path / "custom-hedging"
-        monkeypatch.setenv("FIN_GURU_HEDGING_DIR", str(explicit))
-        reloaded = importlib.reload(rolling_tracker)
-        try:
-            assert explicit == reloaded.HEDGING_DIR
-        finally:
-            monkeypatch.delenv("FIN_GURU_HEDGING_DIR")
-            importlib.reload(rolling_tracker)
+        assert (hedging_dir / "positions.yaml").exists()

--- a/tests/python/test_simplefin_expenses.py
+++ b/tests/python/test_simplefin_expenses.py
@@ -1,6 +1,8 @@
 import sqlite3
 from copy import deepcopy
+from pathlib import Path
 
+from src.integrations.simplefin import sync_expenses_db
 from src.integrations.simplefin.categorize import (
     NON_SPEND_CATEGORIES,
     categorize_expense,
@@ -10,6 +12,16 @@ from src.integrations.simplefin.sync_expenses_db import (
     resolve_direction,
     sync,
 )
+
+
+def test_default_app_dir_is_checkout_owned(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    repo_root = Path(sync_expenses_db.__file__).resolve().parents[3]
+    expected_app_dir = repo_root / "apps" / "simplefin-sync"
+
+    assert expected_app_dir == sync_expenses_db.DEFAULT_APP_DIR
+    assert sync_expenses_db.DEFAULT_APP_DIR.is_absolute()
+
 
 SFIN_ACCOUNT_SET = {
     "accounts": [

--- a/tests/python/test_snaptrade_db_sync.py
+++ b/tests/python/test_snaptrade_db_sync.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from src.config.instance_paths import InstancePaths, _db_path
-from src.integrations.snaptrade.sync_db import _net_positions
+from src.integrations.snaptrade.sync_db import (
+    _net_positions,
+)
+from src.integrations.snaptrade.sync_db import (
+    main as sync_positions_main,
+)
 from src.integrations.snaptrade.sync_transactions_db import _dedupe_key
 
 
@@ -86,6 +93,24 @@ def test_db_path_resolves_relative_locations_under_instance_root(
         tmp_path / "family_office.db"
     )
     assert _db_path("family_office.db", paths) == tmp_path / "family_office.db"
+
+
+def test_sync_cli_reads_default_account_config_from_instance_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    instance_root = tmp_path / "instance"
+    working_directory = tmp_path / "cwd"
+    instance_root.mkdir()
+    working_directory.mkdir()
+    (instance_root / "snaptrade-accounts.yaml").write_text(
+        "accounts: []\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(instance_root))
+    monkeypatch.chdir(working_directory)
+
+    assert sync_positions_main([]) == 0
+    assert (instance_root / "family_office.db").exists()
 
 
 def test_categorize_matches_and_prioritizes_transfers() -> None:

--- a/tests/python/test_snaptrade_db_sync.py
+++ b/tests/python/test_snaptrade_db_sync.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from src.integrations.snaptrade.sync_db import _db_path, _net_positions
+from pathlib import Path
+
+from src.config.instance_paths import InstancePaths, _db_path
+from src.integrations.snaptrade.sync_db import _net_positions
 from src.integrations.snaptrade.sync_transactions_db import _dedupe_key
 
 
@@ -73,10 +76,16 @@ def test_dedupe_key_stable_and_distinguishes_same_day_dividends() -> None:
     assert _dedupe_key("acct1", a) != _dedupe_key("acct1", b)
 
 
-def test_db_path_parses_sqlite_url() -> None:
-    """sqlite:///rel.db -> relative; bare path passes through."""
-    assert str(_db_path("sqlite:///family_office.db")) == "family_office.db"
-    assert str(_db_path("family_office.db")) == "family_office.db"
+def test_db_path_resolves_relative_locations_under_instance_root(
+    tmp_path: Path,
+) -> None:
+    """SQLite URLs and bare paths resolve under the instance root."""
+    paths = InstancePaths(root=tmp_path)
+
+    assert _db_path("sqlite:///family_office.db", paths) == (
+        tmp_path / "family_office.db"
+    )
+    assert _db_path("family_office.db", paths) == tmp_path / "family_office.db"
 
 
 def test_categorize_matches_and_prioritizes_transfers() -> None:

--- a/tests/python/test_snaptrade_db_sync.py
+++ b/tests/python/test_snaptrade_db_sync.py
@@ -107,6 +107,7 @@ def test_sync_cli_reads_default_account_config_from_instance_root(
         encoding="utf-8",
     )
     monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(instance_root))
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.chdir(working_directory)
 
     assert sync_positions_main([]) == 0

--- a/tests/python/test_snaptrade_integration.py
+++ b/tests/python/test_snaptrade_integration.py
@@ -213,8 +213,11 @@ def test_probe_account_reports_phase_0_diagnostics():
     assert probe["average_purchase_price_missing_count"] == 1
 
 
-def test_credentials_from_env_reports_missing_keys(monkeypatch: pytest.MonkeyPatch):
+def test_credentials_from_env_reports_missing_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
     """Missing SnapTrade env keys fail closed with key names only."""
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
     for key in (
         "SNAPTRADE_CLIENT_ID",
         "SNAPTRADE_CONSUMER_KEY",

--- a/tests/python/test_snaptrade_integration.py
+++ b/tests/python/test_snaptrade_integration.py
@@ -248,7 +248,13 @@ def test_accounts_cli_writes_unassigned_disabled_config(
     monkeypatch.setattr(
         "src.integrations.snaptrade.cli.SnapTradeClientWrapper", FakeWrapper
     )
-    config_path = tmp_path / "snaptrade-accounts.yaml"
+    instance_root = tmp_path / "instance"
+    working_directory = tmp_path / "cwd"
+    instance_root.mkdir()
+    working_directory.mkdir()
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(instance_root))
+    monkeypatch.chdir(working_directory)
+    config_path = instance_root / "snaptrade-accounts.yaml"
 
     exit_code = main(
         [
@@ -256,7 +262,6 @@ def test_accounts_cli_writes_unassigned_disabled_config(
             "--output",
             "json",
             "--write-config",
-            str(config_path),
         ]
     )
 

--- a/tests/python/test_total_return.py
+++ b/tests/python/test_total_return.py
@@ -45,7 +45,7 @@ from src.models.total_return_inputs import (
 )
 
 # ---------------------------------------------------------------------------
-# Mock dividend schedules (for CI where fin-guru-private/ doesn't exist)
+# Mock dividend schedules for CI instances without a schedule file.
 # ---------------------------------------------------------------------------
 
 MOCK_DIVIDEND_SCHEDULES = {
@@ -635,14 +635,15 @@ class TestScheduleLoader:
         for ticker in ["SCHD", "VYM", "VOO"]:
             assert schedules.get(ticker, {}).get("frequency") == 4
 
-    def test_missing_file_returns_empty_dict(self, _mock):
+    def test_missing_file_returns_empty_dict(
+        self, _mock, monkeypatch, tmp_path: Path
+    ) -> None:
         """If YAML file does not exist, return empty dict (graceful fallback)."""
-        with patch(
-            "src.analysis.total_return.DIVIDEND_SCHEDULES_PATH",
-            Path("/nonexistent/path/dividend-schedules.yaml"),
-        ):
-            schedules = load_dividend_schedules()
-            assert schedules == {}
+        monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+
+        schedules = load_dividend_schedules()
+
+        assert schedules == {}
 
 
 # ---------------------------------------------------------------------------
@@ -1156,37 +1157,14 @@ class TestFetchTickerDataAutoAdjust:
         assert [dividend.amount for dividend in divs] == [1.0]
 
 
-class TestEnvVarOverrides:
-    """Verify module-level path constants honor their env var overrides."""
+class TestInstancePaths:
+    """Verify schedule loading resolves the instance root at call time."""
 
-    def test_private_dir_env_var_shifts_dividend_schedules_default(
-        self, monkeypatch, tmp_path
-    ):
-        import importlib
+    def test_data_root_selects_dividend_schedule(self, monkeypatch, tmp_path: Path):
+        schedules_path = tmp_path / "dividend-schedules.yaml"
+        schedules_path.write_text("SYNTH: {frequency: 4, label: quarterly}\n")
+        monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
 
-        from src.analysis import total_return
-
-        monkeypatch.setenv("FIN_GURU_PRIVATE_DIR", str(tmp_path))
-        reloaded = importlib.reload(total_return)
-        try:
-            assert tmp_path == reloaded.PRIVATE_DIR
-            assert (
-                tmp_path / "dividend-schedules.yaml" == reloaded.DIVIDEND_SCHEDULES_PATH
-            )
-        finally:
-            monkeypatch.delenv("FIN_GURU_PRIVATE_DIR")
-            importlib.reload(total_return)
-
-    def test_dividend_schedules_env_var_takes_precedence(self, monkeypatch, tmp_path):
-        import importlib
-
-        from src.analysis import total_return
-
-        explicit = tmp_path / "custom-schedules.yaml"
-        monkeypatch.setenv("FIN_GURU_DIVIDEND_SCHEDULES", str(explicit))
-        reloaded = importlib.reload(total_return)
-        try:
-            assert explicit == reloaded.DIVIDEND_SCHEDULES_PATH
-        finally:
-            monkeypatch.delenv("FIN_GURU_DIVIDEND_SCHEDULES")
-            importlib.reload(total_return)
+        assert load_dividend_schedules() == {
+            "SYNTH": {"frequency": 4, "label": "quarterly"}
+        }

--- a/tests/python/test_yaml_generation.py
+++ b/tests/python/test_yaml_generation.py
@@ -316,9 +316,9 @@ class TestFullGeneration:
 
         # Verify files were created
         expected_files = [
-            tmp_path / "fin-guru" / "data" / "user-profile.yaml",
-            tmp_path / "fin-guru" / "config.yaml",
-            tmp_path / "fin-guru" / "data" / "system-context.md",
+            tmp_path / "user-profile.yaml",
+            tmp_path / "config.yaml",
+            tmp_path / "system-context.md",
             tmp_path / "CLAUDE.md",
             tmp_path / ".env",
             tmp_path / ".claude" / "mcp.json",

--- a/uv.lock
+++ b/uv.lock
@@ -740,7 +740,7 @@ wheels = [
 [[package]]
 name = "family-office"
 version = "2.2.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Why

Wayfinder #131, phase P2. The engine must read the household's profile, database, CSV exports, and generated documents from a directory outside the checkout, so the repository stops being anyone's working residence. Today each subsystem computes its own repo-relative default with its own env override, and three different profile paths compete. One typed model that owns the layout removes the branching and gives the plugin phase a single contract.

## Scope

- `src/config/instance_paths.py` adds `InstancePaths`, a frozen model with one field, `root`, resolved by `InstancePaths.resolve()` from `FIN_GURU_DATA_ROOT` or the current working directory. Its properties name every private path: `profile`, `config`, `system_context`, `db`, `imports`, `analysis`, `tickets`, `strategies`, `hedging`, `reports`, `dividend_schedules`, `auto_tickets`, `env_file`. `database_url()` honours `DATABASE_URL`, resolves a relative sqlite path under the root, and defaults to `family_office.db` under the root. `load_instance_env()` loads the root's `.env`.
- Callers migrated and legacy logic deleted: `_PROFILE_SEARCH_PATHS` in `config_loader`, `PORTFOLIO_DIR` in `fin_guru_config`, `PRIVATE_DIR`, `HEDGING_DIR`, `DIVIDEND_SCHEDULES_PATH` in `total_return` and `rolling_tracker`, `BALANCES_GLOB` in `hedge_sizer`, the duplicated `_db_path` in `sync_db` and `margin_metrics`, and the `fin-guru-private` write targets in `onboarding_wizard` and `yaml_generator`. `SmokePaths.from_project_root` becomes `SmokePaths.from_instance`.
- Env overrides removed: `FIN_GURU_PRIVATE_DIR`, `FIN_GURU_HEDGING_DIR`, `FIN_GURU_DIVIDEND_SCHEDULES`, `FIN_GURU_PORTFOLIO_DIR`. `.env.example` documents `FIN_GURU_DATA_ROOT` and marks `DATABASE_URL` optional.
- `pyproject.toml` gains a hatchling build section installing `src` and `buy_ticket_agent`, so `uv run --project <repo> python -m src.<tool>` works with an instance directory as cwd.
- The synthetic balance fixture filenames in `tests/python/test_hedge_sizer.py` no longer match the account-number shape. That clears four of the standing findings in #130.
- Out of scope, following in this train: the skill and agent prose sweep, the session hook, and the instance scaffold. A follow-up commit on this branch moves `config/snaptrade-accounts.yaml` under the root as well.

## Tradeoffs

The default root is the cwd rather than the repo root. Running from the checkout keeps today's behaviour because the ignored data still sits there. Running from anywhere else reads that directory instead. That is the point, and it is what the scaffold PR builds on.

`src/utils/market_data.py` still loads `.env` at import time, as before, now from the instance root.

## Blast Radius

Every CLI that touches private data, the SnapTrade and SimpleFIN syncs, the hedging tools, the buy-ticket agent, and the onboarding wizard. Public behaviour of the analysis tools is unchanged. Anyone who set one of the four removed env variables must set `FIN_GURU_DATA_ROOT` instead.

## Verification

- `uv run ruff format . && uv run ruff check .` clean. `uv run mypy src/` clean, 94 files.
- `uv run pytest -m "not integration" -q`: 1087 passed, 1 skipped, coverage 80.9% against the 80% gate. New tests in `tests/python/test_instance_paths.py` and a regression in `test_config_loader.py` were watched failing before the change.
- Live, from a scratch directory outside the checkout holding only a `user-profile.yaml` with a `hedging` section: `uv run --project <repo> python -c ...` printed the scratch root, the scratch database path, its sqlite URL, and the hedging value from that file. Repeated with `FIN_GURU_DATA_ROOT` pointing at a second scratch directory, which won.
- History and push scopes of the privacy scanner pass on this branch. The first push attempt was blocked because the touched fixture lines matched the account-number pattern; the rename above fixed the cause and the commit was rebuilt before anything reached the remote.
- The pre-commit hook's parallel pytest run flaked once on `test_progress_persistence.py` with a pytest-rerunfailures fixture-teardown error. The same file reruns on `main` too. Re-running it three times and the full suite once on this branch was green before the commit went through.

Implemented by a codex worker (gpt-5.6-sol, xhigh) in a herdr pane from a written brief. Reviewed, corrected, and committed by Claude Fable 5.1 running in Claude Code (poteto mode).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized instance data-root configuration through `FIN_GURU_DATA_ROOT`.
  * Configuration, databases, imports, reports, analysis files, tickets, and strategy data now resolve consistently within the selected instance directory.
  * Onboarding and SnapTrade tools now use instance-specific configuration locations.
  * Added packaging support for building distributable application wheels.

* **Bug Fixes**
  * Updated portfolio, balance, dividend, hedging, and transaction workflows to locate files and databases correctly.
  * Improved path-related guidance and error messages across command-line tools.
  * Preserved existing environment settings unless explicit overrides are requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->