### PR TITLE
feat(instance): scaffold a local-only instance directory

### DIFF
--- a/docs/runbooks/instance-migration.md
+++ b/docs/runbooks/instance-migration.md
@@ -1,0 +1,154 @@
+# Move private data into a Finance Guru instance
+
+## Create the instance
+
+1. Create the local instance.
+
+   ```bash
+   uv run --project "<repo>" python -m src.cli.instance_init "<root>" --repo "<repo>"
+   ```
+
+2. Check that the project link exists.
+
+   ```bash
+   test -L "<root>/.claude"
+   ```
+
+## Move the data
+
+1. Move the user profile over the empty instance template.
+
+   ```bash
+   command mv "<repo>/fin-guru/data/user-profile.yaml" "<root>/user-profile.yaml"
+   ```
+
+2. Move the database and each SQLite sidecar that exists.
+
+   ```bash
+   command mv "<repo>/family_office.db" "<root>/family_office.db"
+   command mv "<repo>/family_office.db-wal" "<root>/family_office.db-wal"
+   command mv "<repo>/family_office.db-shm" "<root>/family_office.db-shm"
+   command mv "<repo>/family_office.db-journal" "<root>/family_office.db-journal"
+   ```
+
+3. Move the environment and SnapTrade routing files.
+
+   ```bash
+   command mv "<repo>/.env" "<root>/.env"
+   command mv "<repo>/config/snaptrade-accounts.yaml" "<root>/snaptrade-accounts.yaml"
+   ```
+
+4. Replace the empty report directory with the nested report archive, then merge the second report archive.
+
+   ```bash
+   command rmdir "<root>/reports"
+   command mv "<repo>/fin-guru-private/fin-guru/analysis/reports" "<root>/reports"
+   command mv "<repo>/fin-guru-private/fin-guru/reports/"* "<root>/reports/"
+   ```
+
+5. Move the remaining analysis artifacts.
+
+   ```bash
+   command rmdir "<root>/analysis"
+   command mv "<repo>/fin-guru-private/fin-guru/analysis" "<root>/analysis"
+   ```
+
+6. Move the tickets.
+
+   ```bash
+   command rmdir "<root>/tickets"
+   command mv "<repo>/fin-guru-private/fin-guru/tickets" "<root>/tickets"
+   ```
+
+7. Replace the empty strategy directory with the first strategy archive, then merge the second archive.
+
+   ```bash
+   command rmdir "<root>/strategies"
+   command mv "<repo>/fin-guru-private/strategies" "<root>/strategies"
+   command mv "<repo>/fin-guru-private/fin-guru/strategies/"* "<root>/strategies/"
+   ```
+
+8. Move the hedging records.
+
+   ```bash
+   command rmdir "<root>/hedging"
+   command mv "<repo>/fin-guru-private/hedging" "<root>/hedging"
+   ```
+
+9. Move the dividend schedule.
+
+   ```bash
+   command mv "<repo>/fin-guru-private/dividend-schedules.yaml" "<root>/dividend-schedules.yaml"
+   ```
+
+10. Replace the empty notes directory with the guides, then add the other reference material.
+
+    ```bash
+    command rmdir "<root>/notes"
+    command mv "<repo>/fin-guru-private/guides" "<root>/notes"
+    command mv "<repo>/fin-guru-private/dashboard" "<root>/notes/"
+    command mv "<repo>/fin-guru-private/credit-cards" "<root>/notes/"
+    command mv "<repo>/fin-guru-private/research" "<root>/notes/"
+    command mv "<repo>/fin-guru-private/onboarding-summary.md" "<root>/notes/"
+    command mv "<repo>/fin-guru-private/README.md" "<root>/notes/"
+    command mv "<repo>/fin-guru-private/INDEX.md" "<root>/notes/"
+    command mv "<repo>/.memory/notes/"* "<root>/notes/"
+    command mv "<repo>/.dev/meeting-notes/"* "<root>/notes/"
+    ```
+
+11. Replace the empty imports directory with portfolio updates, then add transaction and retirement exports.
+
+    ```bash
+    command rmdir "<root>/imports"
+    command mv "<repo>/notebooks/updates" "<root>/imports"
+    command mv "<repo>/notebooks/transactions" "<root>/imports/transactions"
+    command mv "<repo>/notebooks/retirement-accounts" "<root>/imports/retirement"
+    ```
+
+## Verify the instance
+
+1. Change to the instance directory.
+
+   ```bash
+   cd "<root>"
+   ```
+
+2. Refresh the local database and print the position and balance tables.
+
+   ```bash
+   uv run --project "<repo>" python -m src.integrations.refresh_all --show
+   ```
+
+3. Check the checkout for unexpected untracked files under the moved paths.
+
+   ```bash
+   git -C "<repo>" status --short --untracked-files=all
+   ```
+
+## Commit the instance
+
+1. Change to the instance directory.
+
+   ```bash
+   cd "<root>"
+   ```
+
+2. Commit the migrated data.
+
+   ```bash
+   git add -A && git commit -m "migrate household data from the checkout"
+   ```
+
+## Start future sessions from the instance
+
+1. Change to the instance directory before starting a Finance Guru session.
+
+   ```bash
+   cd "<root>"
+   ```
+
+2. Check the working directory.
+
+   ```bash
+   pwd
+   ```

--- a/docs/runbooks/instance-migration.md
+++ b/docs/runbooks/instance-migration.md
@@ -8,7 +8,13 @@
    uv run --project "<repo>" python -m src.cli.instance_init "<root>" --repo "<repo>"
    ```
 
-2. Check that the project link exists.
+2. Check that the instance virtual environment exists.
+
+   ```bash
+   test -d "<root>/.venv"
+   ```
+
+3. Check that the project link exists.
 
    ```bash
    test -L "<root>/.claude"
@@ -116,7 +122,7 @@
 2. Refresh the local database and print the position and balance tables.
 
    ```bash
-   uv run --project "<repo>" python -m src.integrations.refresh_all --show
+   uv run python -m src.integrations.refresh_all --show
    ```
 
 3. Check the checkout for unexpected untracked files under the moved paths.
@@ -133,7 +139,7 @@
    cd "<root>"
    ```
 
-2. Commit the migrated data.
+2. Commit the migrated data and `uv.lock`.
 
    ```bash
    git add -A && git commit -m "migrate household data from the checkout"

--- a/docs/runbooks/instance-migration.md
+++ b/docs/runbooks/instance-migration.md
@@ -119,13 +119,19 @@
    cd "<root>"
    ```
 
-2. Refresh the local database and print the position and balance tables.
+2. Refresh the local database from the migrated credentials and routing file.
+
+   ```bash
+   uv run python -m src.integrations.refresh_all
+   ```
+
+3. Print the position and balance tables.
 
    ```bash
    uv run python -m src.integrations.refresh_all --show
    ```
 
-3. Check the checkout for unexpected untracked files under the moved paths.
+4. Check the checkout for unexpected untracked files under the moved paths.
 
    ```bash
    git -C "<repo>" status --short --untracked-files=all

--- a/src/cli/instance_init.py
+++ b/src/cli/instance_init.py
@@ -1,4 +1,8 @@
-"""Create a local Finance Guru instance without overwriting existing files."""
+"""Create a local Finance Guru instance without overwriting existing files.
+
+The scaffold commit runs before uv sync so it cannot include a partial virtual
+environment, and the later migration commit owns ``uv.lock``.
+"""
 
 from __future__ import annotations
 
@@ -17,6 +21,7 @@ GITIGNORE = """.env
 *.db-wal
 *.db-shm
 .claude
+.venv/
 __pycache__/
 """
 
@@ -136,10 +141,32 @@ def _instance_instructions(repo: Path) -> str:
 
 This directory is a Finance Guru instance, and the engine lives at `{repo}`.
 
-Command form: `uv run --project {repo} python -m src.<tool>`
+Command form: `uv run python -m src.<tool>`
 
-Example: `uv run --project {repo} python -m src.integrations.refresh_all --show`
+Example: `uv run python -m src.integrations.refresh_all --show`
 """
+
+
+def _instance_pyproject(repo: Path) -> str:
+    return f"""[project]
+name = "finance-guru-instance"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = ["family-office"]
+
+[tool.uv.sources]
+family-office = {{ path = "{repo}", editable = true }}
+"""
+
+
+def _run_uv_sync(root: Path) -> None:
+    subprocess.run(["uv", "sync", "--quiet"], cwd=root, check=True)
+
+
+def _sync_environment(path: Path) -> StepResult:
+    existed = path.exists()
+    _run_uv_sync(path.parent)
+    return "exists" if existed else "created"
 
 
 def _build_plan(paths: InstancePaths, repo: Path) -> list[PlanStep]:
@@ -160,6 +187,10 @@ def _build_plan(paths: InstancePaths, repo: Path) -> list[PlanStep]:
     plan.extend(
         (
             PlanStep(paths.root / ".gitignore", _write_text(GITIGNORE)),
+            PlanStep(
+                paths.root / "pyproject.toml",
+                _write_text(_instance_pyproject(repo)),
+            ),
             PlanStep(paths.env_file, _write_text(env_content)),
             PlanStep(paths.profile, _write_text(USER_PROFILE)),
             PlanStep(paths.root / ".claude", _create_symlink(repo / ".claude")),
@@ -168,6 +199,7 @@ def _build_plan(paths: InstancePaths, repo: Path) -> list[PlanStep]:
                 _write_text(_instance_instructions(repo)),
             ),
             PlanStep(paths.root / ".git", _initialize_git),
+            PlanStep(paths.root / ".venv", _sync_environment),
         )
     )
     return plan

--- a/src/cli/instance_init.py
+++ b/src/cli/instance_init.py
@@ -1,0 +1,202 @@
+"""Create a local Finance Guru instance without overwriting existing files."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from src.config import InstancePaths
+
+GITIGNORE = """.env
+.DS_Store
+*.db-journal
+*.db-wal
+*.db-shm
+.claude
+__pycache__/
+"""
+
+USER_PROFILE = """# Add instance-specific values after creating the instance.
+system_ownership: {}
+orientation_status: {}
+user_profile:
+  liquid_assets: {}
+  investment_portfolio: {}
+  cash_flow: {}
+  debt_profile: {}
+  preferences: {}
+hedging: {}
+opportunities: {}
+recommended_workflows: {}
+session_context: {}
+"""
+SCAFFOLD_GIT_NAME = "Finance Guru"
+SCAFFOLD_GIT_EMAIL = "finance-guru@example.invalid"
+
+type StepResult = Literal["created", "exists"]
+type StepAction = Callable[[Path], StepResult]
+
+
+@dataclass(frozen=True)
+class PlanStep:
+    """One convergent filesystem operation in the instance plan."""
+
+    target: Path
+    action: StepAction
+
+
+def _create_directory(path: Path) -> StepResult:
+    if path.exists():
+        if not path.is_dir():
+            raise FileExistsError(f"{path} exists and is not a directory")
+        return "exists"
+    path.mkdir(parents=True)
+    return "created"
+
+
+def _write_text(content: str) -> StepAction:
+    def write(path: Path) -> StepResult:
+        if path.exists() or path.is_symlink():
+            return "exists"
+        path.write_text(content, encoding="utf-8")
+        return "created"
+
+    return write
+
+
+def _create_symlink(source: Path) -> StepAction:
+    def create(path: Path) -> StepResult:
+        if path.is_symlink():
+            return "exists"
+        if path.exists():
+            raise FileExistsError(f"{path} exists and is not a symlink")
+        path.symlink_to(source, target_is_directory=True)
+        return "created"
+
+    return create
+
+
+def _run_git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _initialize_git(path: Path) -> StepResult:
+    existed = path.exists()
+    root = path.parent
+    if not existed:
+        subprocess.run(
+            ["git", "init", str(root)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    commit_count = int(_run_git(root, "rev-list", "--count", "--all").stdout)
+    if commit_count == 0:
+        _run_git(root, "add", "-A")
+        _run_git(
+            root,
+            "-c",
+            f"user.name={SCAFFOLD_GIT_NAME}",
+            "-c",
+            f"user.email={SCAFFOLD_GIT_EMAIL}",
+            "commit",
+            "-m",
+            "scaffold instance",
+        )
+
+    return "exists" if existed else "created"
+
+
+def _instance_env(example: str) -> str:
+    lines = example.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith("FIN_GURU_DATA_ROOT="):
+            lines[index] = "FIN_GURU_DATA_ROOT="
+            break
+    else:
+        lines.append("FIN_GURU_DATA_ROOT=")
+    return "\n".join(lines) + "\n"
+
+
+def _instance_instructions(repo: Path) -> str:
+    project_file = repo / "CLAUDE.md"
+    return f"""@{project_file}
+
+# Instance
+
+This directory is a Finance Guru instance, and the engine lives at `{repo}`.
+
+Command form: `uv run --project {repo} python -m src.<tool>`
+
+Example: `uv run --project {repo} python -m src.integrations.refresh_all --show`
+"""
+
+
+def _build_plan(paths: InstancePaths, repo: Path) -> list[PlanStep]:
+    directory_paths = (
+        paths.imports,
+        paths.analysis,
+        paths.tickets,
+        paths.strategies,
+        paths.hedging,
+        paths.reports,
+        paths.auto_tickets,
+        paths.notes,
+    )
+    env_content = _instance_env((repo / ".env.example").read_text(encoding="utf-8"))
+
+    plan = [PlanStep(paths.root, _create_directory)]
+    plan.extend(PlanStep(path, _create_directory) for path in directory_paths)
+    plan.extend(
+        (
+            PlanStep(paths.root / ".gitignore", _write_text(GITIGNORE)),
+            PlanStep(paths.env_file, _write_text(env_content)),
+            PlanStep(paths.profile, _write_text(USER_PROFILE)),
+            PlanStep(paths.root / ".claude", _create_symlink(repo / ".claude")),
+            PlanStep(
+                paths.root / "CLAUDE.md",
+                _write_text(_instance_instructions(repo)),
+            ),
+            PlanStep(paths.root / ".git", _initialize_git),
+        )
+    )
+    return plan
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path, help="Instance directory to create")
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        required=True,
+        help="Finance Guru engine checkout",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Create or complete one Finance Guru instance."""
+    args = _parse_args(argv)
+    paths = InstancePaths(root=args.root.expanduser().resolve())
+    repo = args.repo.expanduser().resolve()
+
+    for step in _build_plan(paths, repo):
+        result = step.action(step.target)
+        print(f"{result} {step.target}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/config/instance_paths.py
+++ b/src/config/instance_paths.py
@@ -104,6 +104,11 @@ class InstancePaths(BaseModel):
         """Return the automated-ticket runtime directory."""
         return self.root / "auto-tickets"
 
+    @property
+    def notes(self) -> Path:
+        """Return the instance notes and meeting records directory."""
+        return self.root / "notes"
+
     def database_url(self, env: Mapping[str, str] | None = None) -> str:
         """Return the configured database URL with relative paths under root."""
         environment = os.environ if env is None else env

--- a/tests/python/test_instance_init.py
+++ b/tests/python/test_instance_init.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import io
 import os
 import subprocess
-import sys
+import tomllib
+import traceback
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 import yaml
 
+from src.cli import instance_init
 from src.config import InstancePaths
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
 GIT_ENV = {
     "GIT_AUTHOR_NAME": "Finance Guru Test",
     "GIT_AUTHOR_EMAIL": "finance-guru@example.invalid",
@@ -36,6 +40,7 @@ def _run_init(
     repo: Path,
     *,
     configure_git_identity: bool = True,
+    sync_roots: list[Path] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     if configure_git_identity:
@@ -49,20 +54,29 @@ def _run_init(
         env["GIT_CONFIG_KEY_0"] = "user.useConfigOnly"
         env["GIT_CONFIG_VALUE_0"] = "true"
 
-    return subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "src.cli.instance_init",
-            str(root),
-            "--repo",
-            str(repo),
-        ],
-        cwd=PROJECT_ROOT,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
+    args = [str(root), "--repo", str(repo)]
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with (
+        mock.patch.dict(os.environ, env, clear=True),
+        mock.patch.object(instance_init, "_run_uv_sync", autospec=True) as sync,
+        redirect_stdout(stdout),
+        redirect_stderr(stderr),
+    ):
+        try:
+            returncode = instance_init.main(args)
+        except Exception:
+            traceback.print_exc()
+            returncode = 1
+
+    if sync_roots is not None:
+        sync_roots.extend(Path(call.args[0]) for call in sync.call_args_list)
+
+    return subprocess.CompletedProcess(
+        args=args,
+        returncode=returncode,
+        stdout=stdout.getvalue(),
+        stderr=stderr.getvalue(),
     )
 
 
@@ -88,9 +102,39 @@ def _managed_file_mtimes(root: Path) -> dict[Path, int]:
 def test_fresh_root_creates_complete_instance(tmp_path: Path) -> None:
     repo = _fake_repo(tmp_path)
     root = tmp_path / "instance"
+    sync_roots: list[Path] = []
 
-    result = _run_init(root, repo)
+    result = _run_init(root, repo, sync_roots=sync_roots)
 
+    claude_text = (root / "CLAUDE.md").read_text(encoding="utf-8")
+    assert (
+        "Command form: `uv run python -m src.<tool>`" in claude_text
+        and "Example: `uv run python -m src.integrations.refresh_all --show`"
+        in claude_text
+        and "--project" not in claude_text
+    )
+    pyproject_path = root / "pyproject.toml"
+    pyproject = (
+        tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+        if pyproject_path.is_file()
+        else None
+    )
+    assert pyproject == {
+        "project": {
+            "name": "finance-guru-instance",
+            "version": "0.0.0",
+            "requires-python": ">=3.12",
+            "dependencies": ["family-office"],
+        },
+        "tool": {
+            "uv": {
+                "sources": {
+                    "family-office": {"path": str(repo), "editable": True},
+                }
+            }
+        },
+    }
+    assert sync_roots == [root]
     assert result.returncode == 0, result.stderr
     assert all(line.startswith("created ") for line in result.stdout.splitlines())
 
@@ -115,7 +159,8 @@ def test_fresh_root_creates_complete_instance(tmp_path: Path) -> None:
     )
     assert all(path.is_file() for path in expected_files)
     assert (root / ".gitignore").read_text(encoding="utf-8") == (
-        ".env\n.DS_Store\n*.db-journal\n*.db-wal\n*.db-shm\n.claude\n__pycache__/\n"
+        ".env\n.DS_Store\n*.db-journal\n*.db-wal\n*.db-shm\n.claude\n.venv/\n"
+        "__pycache__/\n"
     )
     assert (root / ".claude").is_symlink()
     assert (root / ".claude").resolve() == (repo / ".claude").resolve()
@@ -137,15 +182,9 @@ def test_fresh_root_creates_complete_instance(tmp_path: Path) -> None:
         "session_context",
     }
 
-    claude_text = (root / "CLAUDE.md").read_text(encoding="utf-8")
     assert claude_text.splitlines()[0] == f"@{repo / 'CLAUDE.md'}"
     assert claude_text.index("# Instance") < claude_text.index(
         "This directory is a Finance Guru instance"
-    )
-    assert f"uv run --project {repo} python -m src.<tool>" in claude_text
-    assert (
-        f"uv run --project {repo} python -m src.integrations.refresh_all --show"
-        in claude_text
     )
 
     assert _git(root, "rev-list", "--count", "HEAD") == "1"
@@ -157,12 +196,14 @@ def test_second_run_is_a_no_op(tmp_path: Path) -> None:
     repo = _fake_repo(tmp_path)
     root = tmp_path / "instance"
     first = _run_init(root, repo)
+    (root / ".venv").mkdir()
     before = _managed_file_mtimes(root) if first.returncode == 0 else {}
 
     second = _run_init(root, repo)
 
     assert first.returncode == 0, first.stderr
     assert second.returncode == 0, second.stderr
+    assert f"exists {root / '.venv'}" in second.stdout.splitlines()
     assert all(line.startswith("exists ") for line in second.stdout.splitlines())
     assert _managed_file_mtimes(root) == before
     assert _git(root, "rev-list", "--count", "HEAD") == "1"

--- a/tests/python/test_instance_init.py
+++ b/tests/python/test_instance_init.py
@@ -1,0 +1,208 @@
+"""Behavior tests for the local Finance Guru instance initializer."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from src.config import InstancePaths
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Finance Guru Test",
+    "GIT_AUTHOR_EMAIL": "finance-guru@example.invalid",
+    "GIT_COMMITTER_NAME": "Finance Guru Test",
+    "GIT_COMMITTER_EMAIL": "finance-guru@example.invalid",
+}
+
+
+def _fake_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "engine"
+    (repo / ".claude").mkdir(parents=True)
+    (repo / ".env.example").write_text(
+        "FIN_GURU_DATA_ROOT=/replace/me\nEXAMPLE_SETTING=\n",
+        encoding="utf-8",
+    )
+    (repo / "CLAUDE.md").write_text("# Engine instructions\n", encoding="utf-8")
+    return repo
+
+
+def _run_init(
+    root: Path,
+    repo: Path,
+    *,
+    configure_git_identity: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if configure_git_identity:
+        env.update(GIT_ENV)
+    else:
+        for name in GIT_ENV:
+            env.pop(name, None)
+        env["GIT_CONFIG_GLOBAL"] = os.devnull
+        env["GIT_CONFIG_NOSYSTEM"] = "1"
+        env["GIT_CONFIG_COUNT"] = "1"
+        env["GIT_CONFIG_KEY_0"] = "user.useConfigOnly"
+        env["GIT_CONFIG_VALUE_0"] = "true"
+
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.cli.instance_init",
+            str(root),
+            "--repo",
+            str(repo),
+        ],
+        cwd=PROJECT_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _managed_file_mtimes(root: Path) -> dict[Path, int]:
+    return {
+        path.relative_to(root): path.lstat().st_mtime_ns
+        for path in root.rglob("*")
+        if ".git" not in path.relative_to(root).parts
+        and (path.is_file() or path.is_symlink())
+    }
+
+
+def test_fresh_root_creates_complete_instance(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+
+    result = _run_init(root, repo)
+
+    assert result.returncode == 0, result.stderr
+    assert all(line.startswith("created ") for line in result.stdout.splitlines())
+
+    paths = InstancePaths(root=root)
+    directories = (
+        paths.imports,
+        paths.analysis,
+        paths.tickets,
+        paths.strategies,
+        paths.hedging,
+        paths.reports,
+        paths.auto_tickets,
+        paths.notes,
+    )
+    assert all(path.is_dir() for path in directories)
+
+    expected_files = (
+        root / ".gitignore",
+        paths.env_file,
+        paths.profile,
+        root / "CLAUDE.md",
+    )
+    assert all(path.is_file() for path in expected_files)
+    assert (root / ".gitignore").read_text(encoding="utf-8") == (
+        ".env\n.DS_Store\n*.db-journal\n*.db-wal\n*.db-shm\n.claude\n__pycache__/\n"
+    )
+    assert (root / ".claude").is_symlink()
+    assert (root / ".claude").resolve() == (repo / ".claude").resolve()
+    assert (root / ".git").is_dir()
+
+    env_lines = paths.env_file.read_text(encoding="utf-8").splitlines()
+    assert "FIN_GURU_DATA_ROOT=" in env_lines
+    assert "FIN_GURU_DATA_ROOT=/replace/me" not in env_lines
+    assert "EXAMPLE_SETTING=" in env_lines
+
+    profile = yaml.safe_load(paths.profile.read_text(encoding="utf-8"))
+    assert set(profile) == {
+        "system_ownership",
+        "orientation_status",
+        "user_profile",
+        "hedging",
+        "opportunities",
+        "recommended_workflows",
+        "session_context",
+    }
+
+    claude_text = (root / "CLAUDE.md").read_text(encoding="utf-8")
+    assert claude_text.splitlines()[0] == f"@{repo / 'CLAUDE.md'}"
+    assert claude_text.index("# Instance") < claude_text.index(
+        "This directory is a Finance Guru instance"
+    )
+    assert f"uv run --project {repo} python -m src.<tool>" in claude_text
+    assert (
+        f"uv run --project {repo} python -m src.integrations.refresh_all --show"
+        in claude_text
+    )
+
+    assert _git(root, "rev-list", "--count", "HEAD") == "1"
+    assert _git(root, "log", "-1", "--format=%s") == "scaffold instance"
+    assert _git(root, "remote") == ""
+
+
+def test_second_run_is_a_no_op(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+    first = _run_init(root, repo)
+    before = _managed_file_mtimes(root) if first.returncode == 0 else {}
+
+    second = _run_init(root, repo)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert all(line.startswith("exists ") for line in second.stdout.splitlines())
+    assert _managed_file_mtimes(root) == before
+    assert _git(root, "rev-list", "--count", "HEAD") == "1"
+
+
+def test_existing_profile_is_preserved_byte_for_byte(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+    root.mkdir()
+    profile = root / "user-profile.yaml"
+    original = b"user_profile:\n  custom: preserved\n"
+    profile.write_bytes(original)
+
+    result = _run_init(root, repo)
+
+    assert result.returncode == 0, result.stderr
+    assert profile.read_bytes() == original
+    assert f"exists {profile}" in result.stdout.splitlines()
+
+
+def test_real_claude_directory_fails_and_names_path(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+    conflict = root / ".claude"
+    conflict.mkdir(parents=True)
+
+    result = _run_init(root, repo)
+
+    assert result.returncode != 0
+    assert str(conflict) in result.stderr
+
+
+def test_scaffold_commit_does_not_require_user_git_identity(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+
+    result = _run_init(root, repo, configure_git_identity=False)
+
+    assert result.returncode == 0, result.stderr
+    assert _git(root, "log", "-1", "--format=%s") == "scaffold instance"
+    assert _git(root, "log", "-1", "--format=%an <%ae>") == (
+        "Finance Guru <finance-guru@example.invalid>"
+    )


### PR DESCRIPTION
## Why

Wayfinder #131, phase P2, last step. #133 lets the engine read from an instance directory and #134 points the agents at it. Nothing yet creates that directory or tells the owner how to move the household's files into it. This PR adds both, so the checkout can stop being a working residence.

Stacked on #136 (the sweep). #133 is merged. Merge #136 first.

## Scope

- `src/cli/instance_init.py`. `uv run --project <repo> python -m src.cli.instance_init <root> --repo <repo>` builds a `PlanStep` list from `InstancePaths` and runs it in one loop. Steps: the eight layout directories, `.gitignore`, `.env` copied from `.env.example` with `FIN_GURU_DATA_ROOT` blank, an empty `user-profile.yaml` template, a `.claude` symlink to the checkout so hooks, skills, and agents load in a session started there, an instance `CLAUDE.md` that imports the project one and states the command form, and `git init` with one `scaffold instance` commit. Each step prints `created` or `exists` and never overwrites. A real file or directory at `.claude` raises.
- `InstancePaths.notes` joins the layout for instance notes and meeting records.
- `docs/runbooks/instance-migration.md`. Numbered how-to for the owner: create the instance, move each private file and directory out of the checkout with one `command mv` per source, verify with `refresh_all --show` from the instance, commit the instance, start sessions there. Paths only, no values.
- `tests/python/test_instance_init.py`. Fresh root creates everything and one commit; second run is a no-op with unchanged mtimes; an existing profile stays byte-identical; a real `.claude` directory fails naming the path; the scaffold commit works on a machine with no git identity configured.

## Tradeoffs

The scaffold commit uses a fixed placeholder identity via `git -c` (`Finance Guru <finance-guru@example.invalid>`) because the first live run failed on a machine with no configured author, and the initializer must not write git config. The `.invalid` domain cannot receive mail. Flagging it because it is a literal identity in code; the alternative is to skip the commit when no identity is set.

The runbook removes each empty scaffolded directory immediately before moving the primary source directory onto it, then merges secondary sources with a second `mv`. That keeps the flat layout without a recursive copy.

## Blast Radius

Additive. No existing caller changes. The owner's data does not move until the runbook is followed by hand.

## Verification

- `uv run ruff format . && uv run ruff check .` clean. `uv run mypy src/` clean, 95 files.
- The four prescribed tests failed before the module existed, then passed. The git-identity regression reproduced the live failure with `user.useConfigOnly=true` before the fix.
- `uv run pytest -q` on the full suite: 1095 passed, 2 skipped, coverage 81.6% against the 80% gate. A two-file selection alone trips the whole-repo coverage gate by construction, so the full run is the evidence.
- Live: the init ran twice against a scratch root under the session scratch directory with `--repo` pointing at this checkout. First run printed `created` for all 15 targets, second run printed `exists` for all 15, `git log` showed one commit, and `InstancePaths.resolve().profile.exists()` from that root printed `True`.
- History and push scopes of the privacy scanner pass on this branch. The pre-commit pytest hook flaked once on the known `test_progress_persistence.py` rerun interaction and passed on the second run.

Implemented by a codex worker (gpt-5.6-sol, xhigh) in a herdr pane from a written brief. Reviewed and committed by Claude Fable 5.1 running in Claude Code (poteto mode).