### PR TITLE
test(onboarding): isolate the progress-persistence state file per test

### DIFF
--- a/tests/python/test_progress_persistence.py
+++ b/tests/python/test_progress_persistence.py
@@ -19,6 +19,8 @@ Test Categories:
 import json
 from datetime import datetime, timedelta
 
+import pytest
+
 from src.utils.progress_persistence import (
     ALL_SECTIONS,
     clear_state,
@@ -36,18 +38,21 @@ from src.utils.progress_persistence import (
 )
 
 
+@pytest.fixture(autouse=True)
+def isolated_state_file(tmp_path, monkeypatch):
+    """Give every test its own directory for the onboarding state file.
+
+    ``progress_persistence.get_state_path`` resolves ``STATE_FILE`` against
+    ``Path.cwd()``, so without this the whole suite shares one repo-root
+    ``.onboarding-state.json``. Under ``-n auto`` that file is read, written,
+    and unlinked concurrently by every xdist worker, which produces torn reads
+    and ``FileNotFoundError`` out of ``clear_state``'s check-then-unlink.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 class TestStateManagement:
     """Test state creation, save, and load operations."""
-
-    def setup_method(self):
-        """Clean up any existing state before each test."""
-        if has_existing_state():
-            clear_state()
-
-    def teardown_method(self):
-        """Clean up state after each test."""
-        if has_existing_state():
-            clear_state()
 
     def test_create_new_state(self):
         """New state should be initialized correctly."""
@@ -127,16 +132,6 @@ class TestStateManagement:
 class TestSectionTracking:
     """Test section completion tracking."""
 
-    def setup_method(self):
-        """Clean up before each test."""
-        if has_existing_state():
-            clear_state()
-
-    def teardown_method(self):
-        """Clean up after each test."""
-        if has_existing_state():
-            clear_state()
-
     def test_mark_section_complete(self):
         """Should add section to completed list."""
         state = create_new_state()
@@ -186,16 +181,6 @@ class TestSectionTracking:
 
 class TestDataPersistence:
     """Test section data save/retrieve."""
-
-    def setup_method(self):
-        """Clean up before each test."""
-        if has_existing_state():
-            clear_state()
-
-    def teardown_method(self):
-        """Clean up after each test."""
-        if has_existing_state():
-            clear_state()
 
     def test_save_section_data(self):
         """Should save data for a section."""
@@ -258,16 +243,6 @@ class TestDataPersistence:
 class TestProgressCalculation:
     """Test progress tracking and next section logic."""
 
-    def setup_method(self):
-        """Clean up before each test."""
-        if has_existing_state():
-            clear_state()
-
-    def teardown_method(self):
-        """Clean up after each test."""
-        if has_existing_state():
-            clear_state()
-
     def test_get_next_section_at_start(self):
         """Should return first section when nothing completed."""
         state = create_new_state()
@@ -321,16 +296,6 @@ class TestProgressCalculation:
 
 class TestTimeTracking:
     """Test time since last update calculations."""
-
-    def setup_method(self):
-        """Clean up before each test."""
-        if has_existing_state():
-            clear_state()
-
-    def teardown_method(self):
-        """Clean up after each test."""
-        if has_existing_state():
-            clear_state()
 
     def test_just_now(self):
         """Recent update should show 'just now'."""
@@ -396,16 +361,6 @@ class TestTimeTracking:
 
 class TestEdgeCases:
     """Edge case handling and error scenarios."""
-
-    def setup_method(self):
-        """Clean up before each test."""
-        if has_existing_state():
-            clear_state()
-
-    def teardown_method(self):
-        """Clean up after each test."""
-        if has_existing_state():
-            clear_state()
 
     def test_corrupted_state_file(self):
         """Should handle corrupted JSON gracefully."""


### PR DESCRIPTION
## Why

`tests/python/test_progress_persistence.py` failed the pre-commit hook and CI several times today with `ERROR at setup` and `assert not self._finalizers`. Every test in the file resolved the onboarding state file against the process cwd, so all 32 tests shared one `<repo>/.onboarding-state.json` across fourteen xdist workers.

## Scope

- An autouse fixture chdirs each test into its own `tmp_path`, so `get_state_path()` resolves to a unique file per test.
- The six `setup_method` and `teardown_method` pairs that existed only to scrub the shared file are deleted; they were the racy call sites.
- `src/` is unchanged. Two latent weaknesses remain there and are tracked separately: `clear_state` is check-then-unlink and `save_state` writes non-atomically.

## Blast Radius

One test file. No production code. The test suite stops writing a real file into the repo root on every run.

## Verification

- Reproduced before the change with a five-run loop at `-n 14`: torn reads (`assert None is not None`) and `FileNotFoundError` out of `clear_state`.
- After the change, twenty consecutive runs of the file at `-n 14 -p no:cacheprovider --no-cov` were 32 passed each, zero reruns, zero errors.
- `uv run pytest -m "not integration" -q`: 1100 passed, coverage 81.5%. ruff and mypy clean.

Root-caused and fixed by a Claude Opus 5 lane (xhigh) from a written brief; reviewed and committed by Claude Fable 5.1 running in Claude Code as the program coordinator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved progress persistence test isolation by running each test in a temporary directory.
  * Prevented conflicts between parallel test runs and shared state files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->