### PR TITLE
fix(instance): ignore inherited git environment when scaffolding

### DIFF
--- a/src/cli/instance_init.py
+++ b/src/cli/instance_init.py
@@ -7,6 +7,7 @@ environment, and the later migration commit owns ``uv.lock``.
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -85,12 +86,19 @@ def _create_symlink(source: Path) -> StepAction:
     return create
 
 
+def _git_env() -> dict[str, str]:
+    return {
+        name: value for name, value in os.environ.items() if not name.startswith("GIT_")
+    }
+
+
 def _run_git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", "-C", str(root), *args],
         check=True,
         capture_output=True,
         text=True,
+        env=_git_env(),
     )
 
 
@@ -103,6 +111,7 @@ def _initialize_git(path: Path) -> StepResult:
             check=True,
             capture_output=True,
             text=True,
+            env=_git_env(),
         )
 
     commit_count = int(_run_git(root, "rev-list", "--count", "--all").stdout)

--- a/tests/python/test_instance_init.py
+++ b/tests/python/test_instance_init.py
@@ -11,6 +11,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+import pytest
 import yaml
 
 from src.cli import instance_init
@@ -86,6 +87,11 @@ def _git(root: Path, *args: str) -> str:
         check=True,
         capture_output=True,
         text=True,
+        env={
+            name: value
+            for name, value in os.environ.items()
+            if not name.startswith("GIT_")
+        },
     )
     return result.stdout.strip()
 
@@ -247,3 +253,61 @@ def test_scaffold_commit_does_not_require_user_git_identity(tmp_path: Path) -> N
     assert _git(root, "log", "-1", "--format=%an <%ae>") == (
         "Finance Guru <finance-guru@example.invalid>"
     )
+
+
+def test_scaffold_commit_ignores_inherited_git_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hook_repo = tmp_path / "hook-repo"
+    clean_env = {
+        name: value for name, value in os.environ.items() if not name.startswith("GIT_")
+    }
+    subprocess.run(
+        ["git", "init", str(hook_repo)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=clean_env,
+    )
+    (hook_repo / "outer.txt").write_text("outer\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(hook_repo), "add", "outer.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=clean_env,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(hook_repo),
+            "-c",
+            "user.name=Hook Repo",
+            "-c",
+            "user.email=hook@example.invalid",
+            "commit",
+            "-m",
+            "outer commit",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=clean_env,
+    )
+    git_dir = hook_repo / ".git"
+    monkeypatch.setenv("GIT_DIR", str(git_dir))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(git_dir / "index"))
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+
+    result = _run_init(root, repo)
+
+    git_log = subprocess.run(
+        ["git", "-C", str(root), "log", "-1", "--format=%s"],
+        capture_output=True,
+        text=True,
+        env=clean_env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert git_log.stdout.strip() == "scaffold instance"


### PR DESCRIPTION
## Why

Running `instance_init` from inside a git hook, or from any process where `GIT_DIR` and `GIT_INDEX_FILE` are set, made its `git rev-list` answer for the enclosing repository. The scaffold saw history, skipped its own commit, and later `git log` calls read the wrong repo. The repo's pre-commit hook runs the test suite, so three `test_instance_init` cases failed on every commit made on a machine where the hook exports those variables.

## Scope

- `src/cli/instance_init.py`: one `_git_env()` builder that drops every `GIT_*` variable, passed to both git subprocess sites.
- `tests/python/test_instance_init.py`: one regression that points `GIT_DIR` and `GIT_INDEX_FILE` at a throwaway repo and asserts the fresh instance's latest commit is `scaffold instance`; the test helper that reads git state is sanitized the same way. The five existing tests are unchanged.

## Blast Radius

The initializer only. Behaviour outside a hook is identical.

## Verification

- Reproduction with `GIT_DIR` and `GIT_INDEX_FILE` set: 3 failed before, 6 passed after.
- The new regression failed before the fix (`'' == 'scaffold instance'`) and passes after.
- Full non-integration suite green; ruff and mypy clean. This commit itself was made through the pre-commit hook on the machine where the failure reproduced.

Root-caused by the coordinator, fixed by a codex lane (gpt-5.6-sol, xhigh) from a written brief; reviewed and committed by Claude Fable 5.1 running in Claude Code as the program coordinator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository initialization so scaffold commits are created correctly even when inherited Git environment variables point to another repository.
  * Git operations now ignore conflicting inherited Git settings, improving reliability during instance setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->