### PR TITLE
chore(privacy): clear the standing layer-7 and pattern findings

### DIFF
--- a/.claude/skills/FinanceReport/StyleGuide.md
+++ b/.claude/skills/FinanceReport/StyleGuide.md
@@ -69,7 +69,7 @@ BLACK = "#000000"      # Emphasis text
 │                    • Market Researcher (Dr. Aleksandr Petrov) │
 │                    • Quant Analyst                          │
 │                    • Strategy Advisor                       │
-│  Current Price:    $740.62                                  │
+│  Current Price:    <market price>                           │
 │  YTD Performance:  +24.89%                                  │
 │  Expense Ratio:    0.10%                                    │
 └─────────────────────────────────────────────────────────────┘

--- a/.dev/specs/archive/agent-itc-integration-compliance.md
+++ b/.dev/specs/archive/agent-itc-integration-compliance.md
@@ -131,7 +131,7 @@ The Compliance Officer agent is missing ITC Risk Models API integration that was
     <output_interpretation>
       Current Risk Score: 0.82 (HIGH)
       Risk Level: 🔴 HIGH (> 0.7)
-      Current Price: $445.23
+      Current Price: [market price]
       High Risk Threshold: $500 (distance: +12.3%)
 
       Compliance Decision: CONDITIONAL APPROVAL

--- a/tests/integration/gitignore-protection.test.ts
+++ b/tests/integration/gitignore-protection.test.ts
@@ -47,7 +47,7 @@ describe("Gitignore Protection Integration Test", () => {
 
     // Create test CSV files
     const csvFiles = [
-      "notebooks/updates/Portfolio_Positions_Jan-12-2026.csv",
+      "notebooks/updates/Portfolio_Positions_SAMPLE.csv",
       "notebooks/updates/dividend.csv",
       "notebooks/retirement-accounts/OfxDownload.csv",
       "notebooks/transactions/History_for_Account_EXAMPLE123.csv",

--- a/tests/integration/test_gitignore_protection.sh
+++ b/tests/integration/test_gitignore_protection.sh
@@ -79,8 +79,8 @@ mkdir -p sensitive
 mkdir -p credentials
 
 # Create test CSV files (portfolio positions)
-echo "Date,Ticker,Shares,Price,Value" > notebooks/updates/Portfolio_Positions_Jan-12-2026.csv
-echo "2026-01-12,TSLA,100,350.00,35000.00" >> notebooks/updates/Portfolio_Positions_Jan-12-2026.csv
+echo "Date,Ticker,Shares,Price,Value" > notebooks/updates/Portfolio_Positions_SAMPLE.csv
+echo "2026-01-12,TSLA,100,350.00,35000.00" >> notebooks/updates/Portfolio_Positions_SAMPLE.csv
 
 echo "Date,Ticker,Shares,Price,Value" > notebooks/updates/dividend.csv
 echo "2026-01-12,SCHD,500,75.00,37500.00" >> notebooks/updates/dividend.csv
@@ -129,7 +129,7 @@ log_success "Sensitive test files created"
 log_step "Test 3: Verifying CSV files are ignored"
 
 csv_files=(
-    "notebooks/updates/Portfolio_Positions_Jan-12-2026.csv"
+    "notebooks/updates/Portfolio_Positions_SAMPLE.csv"
     "notebooks/updates/dividend.csv"
     "notebooks/retirement-accounts/OfxDownload.csv"
     "notebooks/transactions/History_for_Account_EXAMPLE123.csv"


### PR DESCRIPTION
## Why

Issue #130 tracked the privacy scanner's standing findings on main: two precise market prices in style examples and four synthetic export filenames in the gitignore integration tests that matched the positions-export pattern. None was household data, but each kept the tree scan red and could trip the push gate on any commit touching those lines.

## Scope

- `.claude/skills/FinanceReport/StyleGuide.md` and `.dev/specs/archive/agent-itc-integration-compliance.md`: the price figure is a placeholder.
- `tests/integration/gitignore-protection.test.ts` and `tests/integration/test_gitignore_protection.sh`: the fixture is `Portfolio_Positions_SAMPLE.csv` and the tests exercise the same ignore rules.
- No allowlist entry, scanner rule, or `src/` change.

## Verification

- `scan.py --scope tree --skip-existing-tests`: PASS, no findings.
- Shell integration test: all passed. Bun integration test: 12 pass.
- Full non-integration suite green, coverage 81.5%.

Closes #130.

Built by a codex lane (gpt-5.6-sol, xhigh) on dev-substrate from a written brief; reviewed and committed by Claude Fable 5.1 running in Claude Code as the program coordinator.