### PR TITLE
fix(deps): cap the SnapTrade SDK below 12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "questionary>=2.1.1",
     "pillow>=12.1.1",
     "anthropic>=0.107.1",
-    "snaptrade-python-sdk>=11.0.197",
+    "snaptrade-python-sdk>=11.0.197,<12",
 ]
 
 [build-system]

--- a/tests/python/test_snaptrade_sdk_dependency.py
+++ b/tests/python/test_snaptrade_sdk_dependency.py
@@ -1,0 +1,19 @@
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+def test_snaptrade_sdk_stays_on_supported_major_version() -> None:
+    pyproject_path = Path(__file__).parents[2] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    requirement = next(
+        Requirement(dependency)
+        for dependency in pyproject["project"]["dependencies"]
+        if Requirement(dependency).name == "snaptrade-python-sdk"
+    )
+
+    assert Version("11.0.197") in requirement.specifier
+    assert Version("11.999.999") in requirement.specifier
+    assert Version("12.0.0") not in requirement.specifier

--- a/uv.lock
+++ b/uv.lock
@@ -813,7 +813,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "scipy", specifier = ">=1.16.2" },
-    { name = "snaptrade-python-sdk", specifier = ">=11.0.197" },
+    { name = "snaptrade-python-sdk", specifier = ">=11.0.197,<12" },
     { name = "streamlit", specifier = ">=1.50.0" },
     { name = "textual", specifier = ">=6.6.0" },
     { name = "urllib3", specifier = ">=2.6.3" },


### PR DESCRIPTION
## Why

A fresh instance created by `instance_init` resolves dependencies from scratch and picked snaptrade-python-sdk 13.0.13, whose constructor requires `auth` and rejects `consumer_key` and `client_id`. Every SnapTrade call from the instance failed while the checkout, locked at 11.0.209, worked. The declared range had no upper bound.

## Scope

- `pyproject.toml`: `snaptrade-python-sdk>=11.0.197,<12`. The lock keeps 11.0.209.
- `tests/python/test_snaptrade_sdk_dependency.py`: the specifier accepts the 11.x range and rejects 12.0.0.

## Tradeoffs

Adapting the client to 13.x was inspected and rejected for now: the 13.x constructor and root client shape differ beyond a keyword rename.

## Verification

- A scratch instance depending on this branch resolved 11.0.213 and imported the client.
- The regression failed before the pin and passes after. Full suite green.

Refs #131.

Built by a codex lane (gpt-5.6-sol, xhigh) on dev-substrate from a written brief; reviewed and committed by Claude Fable 5.1 running in Claude Code as the program coordinator.