### PR TITLE
docs(skills): fix the five skill and onboarding contract bugs

### DIFF
--- a/.claude/commands/fin-guru/agents/compliance-officer.md
+++ b/.claude/commands/fin-guru/agents/compliance-officer.md
@@ -87,7 +87,7 @@
   <execution-steps>
     <step n="1" name="Identify Scope">
       Determine which portfolio positions have ITC coverage.
-      Use: uv run python -m src.analysis.itc_risk_cli --list-supported
+      Use: uv run python -m src.analysis.itc_risk_cli --list-supported tradfi
       Cross-reference with current holdings from DataHub.
     </step>
 

--- a/.claude/skills/FinanceReport/workflows/RegenerateBatch.md
+++ b/.claude/skills/FinanceReport/workflows/RegenerateBatch.md
@@ -14,7 +14,17 @@ Regenerate reports for multiple tickers using parallel subagents.
 
 ## Workflow Steps
 
-### Step 1: Identify Tickers
+### Step 1: Capture Batch Date
+
+Compute the simulation date once before launching any subagents:
+
+```bash
+simulation_date=$(date +%Y-%m-%d)
+```
+
+Store that value as `{simulation_date}` and reuse it for every output in the batch.
+
+### Step 2: Identify Tickers
 
 **Batch 1 (Original 8):**
 - CRWD, BRK.B, APLD, IREN, GOOG, MSFT, SOFI, VTV
@@ -22,7 +32,7 @@ Regenerate reports for multiple tickers using parallel subagents.
 **Batch 2 (Added 9):**
 - VGT, NVDA, AVGO, PLTR, META, VRT, AMZN, FTNT, ARM
 
-### Step 2: Launch Parallel Subagents
+### Step 3: Launch Parallel Subagents
 
 Use the Task tool to launch one subagent per ticker:
 
@@ -53,7 +63,7 @@ for ticker in ["CRWD", "BRKB", "APLD", "IREN", "GOOG", "MSFT", "SOFI", "VTV"]:
            - Build comprehensive 8-10 page report
            - Use VGT-style header
            - Include all quant data
-           - Save to reports/{ticker}-analysis-2025-12-18.pdf
+           - Save to reports/{ticker}-analysis-{simulation_date}.pdf
 
         Follow the FinanceReport skill workflows.
         Replace existing PDF if present.
@@ -63,14 +73,14 @@ for ticker in ["CRWD", "BRKB", "APLD", "IREN", "GOOG", "MSFT", "SOFI", "VTV"]:
     )
 ```
 
-### Step 3: Monitor Completion
+### Step 4: Monitor Completion
 
 Each subagent will:
 1. Complete full research workflow
 2. Generate PDF report
 3. Report back with summary
 
-### Step 4: Validate All Reports
+### Step 5: Validate All Reports
 
 After all subagents complete:
 
@@ -80,13 +90,14 @@ ls -la reports/*.pdf
 
 # Verify file sizes
 for f in reports/*.pdf; do
-    echo "$f: $(stat -f%z "$f") bytes"
+    size=$(wc -c < "$f")
+    echo "$f: $size bytes"
 done
 ```
 
-### Step 5: Update Watchlist Document (Optional)
+### Step 6: Update Watchlist Document (Optional)
 
-Update `analysis/2026-watchlist-2025-12-18.md` with:
+Update `analysis/2026-watchlist-{simulation_date}.md` with:
 - Verdict summaries for each ticker
 - Links to PDF reports
 - Consolidated recommendations

--- a/.claude/skills/MonteCarlo/SKILL.md
+++ b/.claude/skills/MonteCarlo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: monte-carlo
-description: Run Monte Carlo simulations for Finance Guru portfolio strategy. USE WHEN user mentions monte carlo OR run simulation OR stress test portfolio OR probability analysis OR income projections OR margin safety analysis. Supports 4-layer portfolio (Growth, Income, Hedge, GOOGL) with auto-detection of current values from Fidelity CSV.
+description: Run Monte Carlo simulations for Finance Guru portfolio strategy. USE WHEN user mentions monte carlo OR run simulation OR stress test portfolio OR probability analysis OR income projections OR margin safety analysis. Supports a 4-layer portfolio (Growth, Income, Hedge, GOOGL) with operator-supplied starting values.
 ---
 
 # MonteCarlo
@@ -20,7 +20,7 @@ Monte Carlo simulation engine for Finance Guru's 4-layer dividend income + margi
 ```
 User: "Run the monte carlo simulation with current portfolio"
 -> Invokes RunSimulation workflow
--> Auto-detects portfolio values from imports/Portfolio_Positions_*.csv
+-> Derives current values, then updates the hard-coded inputs in run_single_scenario()
 -> Runs 10,000 scenarios with v3.0 4-layer model
 -> Outputs JSON summary + full CSV + Excel to analysis/
 ```
@@ -73,8 +73,10 @@ All outputs saved to `analysis/`:
 
 ## Configuration
 
-Simulation parameters are set in `strategies/dividend_margin_monte_carlo.py`:
-- Starting portfolio values (auto-detected or manual)
+The instance-local script at `strategies/dividend_margin_monte_carlo.py` reads starting portfolio values that are hard-coded in `run_single_scenario()`. It does not auto-detect values from CSV. Before each run, follow the `RunSimulation` workflow to derive current values and edit those assignments.
+
+Simulation parameters include:
+- Starting portfolio values (manually set in `run_single_scenario()`)
 - Monthly deployment amounts
 - Bucket allocations and yields
 - Margin schedule
@@ -91,4 +93,4 @@ Simulation parameters are set in `strategies/dividend_margin_monte_carlo.py`:
 Fixes applied:
 - Floor at $0 for all positions (stocks can't go negative)
 - Full portfolio margin ratio (all layers count toward Fidelity margin)
-- Correct starting values from Fidelity CSV
+- Operator-supplied starting values derived from current portfolio data

--- a/.claude/skills/MonteCarlo/workflows/RunSimulation.md
+++ b/.claude/skills/MonteCarlo/workflows/RunSimulation.md
@@ -1,10 +1,11 @@
 # RunSimulation Workflow
 
-Execute the Monte Carlo v3.0 simulation with auto-detected portfolio values.
+Execute the Monte Carlo v3.0 simulation with operator-supplied portfolio values.
 
 ## Prerequisites
 
-- Latest Fidelity positions CSV in `imports/Portfolio_Positions_*.csv`
+- Current portfolio values, optionally derived from the latest Fidelity positions CSV in `imports/Portfolio_Positions_*.csv`
+- Instance-local `strategies/dividend_margin_monte_carlo.py`
 - Python environment configured with `uv`
 
 ## Workflow Steps
@@ -17,15 +18,15 @@ date +"%Y-%m-%d"
 
 Store as `{simulation_date}` for output file naming.
 
-### Step 2: Auto-Detect Portfolio Values
+### Step 2: Derive Portfolio Values
 
-Read the latest Fidelity positions CSV from `imports/`:
+If using the Fidelity CSV fallback, locate the latest positions file in `imports/`:
 
 ```bash
 ls -t imports/Portfolio_Positions_*.csv | head -1
 ```
 
-Parse the CSV to extract current values for each layer:
+Read the current data to determine values for each layer. This step does not update the simulation script automatically:
 
 **Layer 1 (Growth)** - Sum of:
 - PLTR, TSLA, NVDA, AAPL, VOO, FNILX, SPMO, VXUS, FZILX, SOFI, COIN, MSTR

--- a/.claude/skills/dividend-tracking/SKILL.md
+++ b/.claude/skills/dividend-tracking/SKILL.md
@@ -84,7 +84,7 @@ Dividend income against margin interest is the coverage ratio that drives the sc
 
 ## CSV fallback
 
-`imports/dividend.csv` (the Fidelity dividend view export) remains a manual reconciliation source if the live activities sync is unavailable. It is not the primary path.
+`imports/Dividend_Positions_MMM-DD-YYYY.csv` (the Fidelity dividend view export) remains a manual reconciliation source if the live activities sync is unavailable. It is not the primary path.
 
 ## Reference Files
 

--- a/fin-guru/agents/compliance-officer.md
+++ b/fin-guru/agents/compliance-officer.md
@@ -88,7 +88,7 @@
   <execution-steps>
     <step n="1" name="Identify Scope">
       Determine which portfolio positions have ITC coverage.
-      Use: uv run python -m src.analysis.itc_risk_cli --list-supported
+      Use: uv run python -m src.analysis.itc_risk_cli --list-supported tradfi
       Cross-reference with current holdings from the positions table in family_office.db.
     </step>
 

--- a/scripts/onboarding/modules/yaml-generator.ts
+++ b/scripts/onboarding/modules/yaml-generator.ts
@@ -3,7 +3,7 @@
  * Generates configuration files from templates and user data
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 export interface UserData {
@@ -248,9 +248,19 @@ export function writeConfigFile(filePath: string, content: string): void {
  * @param outputDir - Base directory for output files
  */
 export function generateAllConfigs(data: UserData, outputDir: string = process.cwd()): void {
+  const importDirectories = [
+    join(outputDir, 'imports'),
+    join(outputDir, 'imports', 'transactions'),
+    join(outputDir, 'imports', 'retirement')
+  ];
+
+  for (const directory of importDirectories) {
+    mkdirSync(directory, { recursive: true });
+  }
+
   const configs = [
     {
-      path: join(outputDir, 'fin-guru', 'data', 'user-profile.yaml'),
+      path: join(outputDir, 'user-profile.yaml'),
       content: generateUserProfile(data)
     },
     {

--- a/scripts/onboarding/sections/summary.ts
+++ b/scripts/onboarding/sections/summary.ts
@@ -220,7 +220,7 @@ export async function runSummarySection(state: OnboardingState): Promise<Onboard
         console.log('✅ Configuration files generated successfully');
         console.log('');
         console.log('Files created:');
-        console.log('  ✓ fin-guru/data/user-profile.yaml');
+        console.log('  ✓ user-profile.yaml');
         console.log('  ✓ fin-guru/config.yaml');
         console.log('  ✓ fin-guru/data/system-context.md');
         console.log('');

--- a/setup.sh
+++ b/setup.sh
@@ -353,6 +353,11 @@ create_directory_structure() {
 
   # Finance Guru data directory
   create_dir "$PROJECT_ROOT/fin-guru/data"
+
+  # Instance import directories
+  create_dir "$PROJECT_ROOT/imports"
+  create_dir "$PROJECT_ROOT/imports/transactions"
+  create_dir "$PROJECT_ROOT/imports/retirement"
 }
 
 verify_directory_structure() {
@@ -378,6 +383,9 @@ verify_directory_structure() {
     "$PROJECT_ROOT/notebooks/tools-needed"
     "$PROJECT_ROOT/notebooks/tools-needed/done"
     "$PROJECT_ROOT/fin-guru/data"
+    "$PROJECT_ROOT/imports"
+    "$PROJECT_ROOT/imports/transactions"
+    "$PROJECT_ROOT/imports/retirement"
   )
 
   for dir in "${dirs[@]}"; do
@@ -430,7 +438,7 @@ scaffold_file() {
 
 scaffold_config_files() {
   # 1. user-profile.yaml
-  local user_profile="$PROJECT_ROOT/fin-guru/data/user-profile.yaml"
+  local user_profile="$PROJECT_ROOT/user-profile.yaml"
   if scaffold_file "$user_profile" "user profile template"; then
     cat > "$user_profile" << 'PROFILE_EOF'
 # Finance Guru User Profile Configuration

--- a/tests/integration/test_setup_onboarding_integration.sh
+++ b/tests/integration/test_setup_onboarding_integration.sh
@@ -147,6 +147,7 @@ mkdir -p "$TEST_DIR"
 cp "$PROJECT_ROOT/setup.sh" "$TEST_DIR/"
 cp "$PROJECT_ROOT/pyproject.toml" "$TEST_DIR/" 2>/dev/null || true
 cp "$PROJECT_ROOT/uv.lock" "$TEST_DIR/" 2>/dev/null || true
+cp "$PROJECT_ROOT/README.md" "$TEST_DIR/" 2>/dev/null || true
 cp "$PROJECT_ROOT/.env.example" "$TEST_DIR/" 2>/dev/null || true
 
 # Create minimal src/ structure so uv sync can find the project
@@ -192,9 +193,13 @@ assert_dir_exists "$TEST_DIR/notebooks/transactions"
 assert_dir_exists "$TEST_DIR/notebooks/tools-needed"
 assert_dir_exists "$TEST_DIR/notebooks/tools-needed/done"
 assert_dir_exists "$TEST_DIR/fin-guru/data"
+assert_dir_exists "$TEST_DIR/imports"
+assert_dir_exists "$TEST_DIR/imports/transactions"
+assert_dir_exists "$TEST_DIR/imports/retirement"
 
 # Verify config files
-assert_file_exists "$TEST_DIR/fin-guru/data/user-profile.yaml"
+assert_file_exists "$TEST_DIR/user-profile.yaml"
+assert_file_not_exists "$TEST_DIR/fin-guru/data/user-profile.yaml"
 assert_file_exists "$TEST_DIR/fin-guru-private/README.md"
 
 # Verify .env created (if .env.example was present)
@@ -256,6 +261,9 @@ assert_no_grep "/tmp/setup-test-second.log" "FAIL" "No FAIL messages in second r
 assert_dir_exists "$TEST_DIR/fin-guru-private/fin-guru/strategies/active"
 assert_dir_exists "$TEST_DIR/fin-guru-private/hedging"
 assert_dir_exists "$TEST_DIR/fin-guru/data"
+assert_dir_exists "$TEST_DIR/imports"
+assert_dir_exists "$TEST_DIR/imports/transactions"
+assert_dir_exists "$TEST_DIR/imports/retirement"
 
 # Verify no duplicate entries in .setup-progress
 DUP_COUNT=$(sort "$TEST_DIR/.setup-progress" | uniq -d | wc -l | tr -d ' ')

--- a/tests/python/test_onboarding_cli_structure.py
+++ b/tests/python/test_onboarding_cli_structure.py
@@ -150,6 +150,17 @@ class TestOnboardingStructure:
         for func_name in expected_functions:
             assert func_name in content, f"yaml-generator.ts should export {func_name}"
 
+    def test_yaml_generator_uses_instance_root_paths(self, onboarding_dir):
+        """Profile and import paths should match the instance-root contract."""
+        generator_file = onboarding_dir / "modules" / "yaml-generator.ts"
+        content = generator_file.read_text()
+
+        assert "join(outputDir, 'user-profile.yaml')" in content
+        assert "'fin-guru', 'data', 'user-profile.yaml'" not in content
+        assert "join(outputDir, 'imports')" in content
+        assert "join(outputDir, 'imports', 'transactions')" in content
+        assert "join(outputDir, 'imports', 'retirement')" in content
+
     def test_index_entry_point_content(self, onboarding_dir):
         """Test that index.ts has main function and displays"""
         index_file = onboarding_dir / "index.ts"


### PR DESCRIPTION
## Why

Issue #137 listed five documentation contracts that were wrong before the sweep and only relocated by it. Each made a documented command fail as written or a legacy onboarding path write where the engine no longer reads.

## Scope

- `compliance-officer.md` (both copies): `itc_risk_cli --list-supported tradfi`.
- `dividend-tracking/SKILL.md`: the fallback names the ingested export pattern.
- `FinanceReport/workflows/RegenerateBatch.md`: the date is computed once per batch; the size check uses `wc -c`.
- `MonteCarlo/SKILL.md` and `RunSimulation.md`: the contract states operator-supplied inputs.
- `setup.sh` and `scripts/onboarding/**`: write `user-profile.yaml` at the instance root and create the three import directories. Focused assertions added to the setup integration test and the onboarding structure test.

## Verification

- Each item has a before and after line in the lane report. Both touched tests pass. Full non-integration suite green.

Closes #137.

Built by a codex lane (gpt-5.6-sol, xhigh) on dev-substrate from a written brief; reviewed and committed by Claude Fable 5.1 running in Claude Code as the program coordinator.