### PR TITLE
docs: reposition the README and setup guides for installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,186 +1,126 @@
 # Finance Guru™
 
-Finance Guru is a local-first financial analysis and automation repository built
-for a private family office workflow. It combines a typed Python analysis
-engine, brokerage-data integrations, operational runbooks, and AI-assisted
-workflows.
+Finance Guru is a self-hosted family office engine for technical operators who
+already run Claude Code or Codex. It combines a typed Python analysis engine
+with agent skills that read your portfolio from a local SQLite database. All of
+it is open under AGPL-3.0. The skills, the agents, and the engine ship
+together, and there is no withheld feature tier. Finance Guru is the free,
+self-hosted, CLI-native experience. Keepfolio is the polished macOS product for
+people who will not run a terminal.
 
-> [!IMPORTANT]
-> The repository is in a product transition. The Python analysis engine and
-> documentation are the stable public surfaces. The Claude Code agent/skill
-> stack remains usable but is transitional. The planned standalone Tauri v2
-> macOS application is described in [the vision document](docs/VISION.md); it
-> is not yet present in this repository.
-
-## What is here today
-
-| Area | Purpose | Status |
-| --- | --- | --- |
-| `src/` | Typed financial calculators, strategies, CLIs, and integrations | Stable |
-| `tests/` | Regression and contract tests; provider tests use an integration marker | Stable |
-| `buy_ticket_agent/` | Guardrailed buy-ticket generation workflow | Internal |
-| `apps/simplefin-sync/` | Bun/TypeScript SimpleFIN ingestion and deposit triggers | Internal |
-| `fin-guru/` and `.claude/` | Specialist agents, skills, hooks, and orchestration | Transitional |
-| `docs/` | Setup guides, reference material, and operating runbooks | Active |
-
-The stable analysis engine covers risk, momentum, volatility, correlation,
-portfolio optimization, backtesting, options, factor analysis, total return,
-hedging, margin metrics, and data validation. See the
-[CLI reference](docs/reference/api.md) for the core command documentation.
+The engine works on day one with broker CSV exports dropped into `imports/`.
+Live sync through SnapTrade and SimpleFIN is optional and uses your own
+credentials.
 
 ## Quick start
 
-### Prerequisites
+You need Python 3.12 or later, [uv](https://docs.astral.sh/uv/), and Git.
 
-- Python 3.12+
-- [uv](https://docs.astral.sh/uv/)
-- Git
-- Bun for onboarding scripts and TypeScript workspaces
-- Claude Code only if you use the transitional agent workflows
-
-### Install
-
-Finance Guru is designed to be forked so private configuration stays separate
-from upstream development.
+Clone the engine, then create an instance directory for your private data. The
+instance is a small uv project that depends on the engine, so engine commands
+run from it with no extra flags.
 
 ```bash
-git clone https://github.com/YOUR-USERNAME/Finance-Guru.git
+git clone https://github.com/AojdevStudio/Finance-Guru.git
 cd Finance-Guru
-./setup.sh
+uv run python -m src.cli.instance_init ~/finance-guru-data --repo .
+cd ~/finance-guru-data
+uv run python -m src.integrations.refresh_all --show
 ```
 
-For analysis-engine development without the interactive setup:
+The last command prints the position, transaction, and expense tables. On a new
+instance it reports an empty database. Drop broker CSV exports into `imports/`
+to work CSV-first, or set up [live sync](#live-sync) later.
+
+Market analysis needs no portfolio data at all. From the instance directory,
+run any engine tool as a module.
 
 ```bash
-uv sync --dev
-uv run pytest
+uv run python -m src.analysis.risk_metrics_cli TSLA --days 252 --benchmark SPY
 ```
 
-The script checks prerequisites, installs Python dependencies, prepares local
-private-data paths, and prints the onboarding command to run next. It does not
-start an agent harness for you.
+See the [CLI reference](docs/reference/api.md) for the full tool list.
 
-## Run the analysis engine
+## Install as a plugin
 
-Every financial tool follows the same core pattern:
-
-```text
-Pydantic input models → calculator or strategy → CLI
-```
-
-Examples:
+This install path lands with the plugin release. It is not on main yet.
 
 ```bash
-# Risk and benchmark metrics
-uv run python src/analysis/risk_metrics_cli.py TSLA --days 252 --benchmark SPY
-
-# Momentum indicators
-uv run python src/utils/momentum_cli.py TSLA --days 90
-
-# Portfolio optimization
-uv run python src/strategies/optimizer_cli.py TSLA PLTR NVDA SPY \
-  --days 252 \
-  --method risk_parity
-
-# Price, dividend, and total-return analysis
-uv run python src/analysis/total_return_cli.py SCHD --days 365
+claude plugin marketplace add AojdevStudio/Finance-Guru
+claude plugin install finance-guru@finance-guru
 ```
 
-Most CLIs support structured output for downstream automation:
+After install, run the `instance-onboarding` skill. It scaffolds the instance
+directory described above and walks through the first CSV import.
 
-```bash
-uv run python src/analysis/risk_metrics_cli.py TSLA --output json
-```
+## What you get
 
-## Use the transitional agent workflows
+| Surface | Location | What it does |
+| --- | --- | --- |
+| Python engine | `src/` | Typed calculators and CLIs for risk, momentum, volatility, correlation, portfolio optimization, backtesting, options, factor analysis, total return, hedging, and margin metrics |
+| Skills | `.claude/skills/` | Workflows for portfolio sync, dividend tracking, margin management, Monte Carlo simulation, market research, report generation, and compliance scanning |
+| Agents | `.claude/commands/fin-guru/agents/` | Specialist financial agents coordinated by the Finance Orchestrator |
 
-After running setup, start your supported harness from the repository root.
-Claude Code users can activate the existing orchestrator with:
+Every tool in the engine follows the same three-layer pattern. Pydantic input
+models feed a calculator class, and a CLI wraps the calculator. Calculations
+stay testable outside any AI session.
 
-```text
-/fin-guru:agents:finance-orchestrator
-```
+## Live sync
 
-The checked-in skill source is `.claude/skills/`.
-
-These surfaces are scheduled for replacement by the standalone application.
-New feature work against agents, skills, hooks, integrations, or other internal
-runtime surfaces starts as an issue rather than a pull request. See
-[Contributing](docs/CONTRIBUTING.md) for the exact boundaries.
-
-## Architecture
-
-```text
-Finance-Guru/
-├── src/
-│   ├── models/          # Pydantic contracts
-│   ├── analysis/        # Risk, return, options, hedging, and factor tools
-│   ├── strategies/      # Portfolio optimization and backtesting
-│   ├── utils/           # Market data, indicators, validation, and logging
-│   ├── integrations/    # Brokerage adapters, including SnapTrade
-│   └── config/          # Configuration loading and defaults
-├── buy_ticket_agent/    # Guardrailed ticket-generation pipeline
-├── apps/
-│   └── simplefin-sync/  # Bun/TypeScript financial-data ingestion
-├── fin-guru/            # Transitional agent module
-├── .claude/             # Transitional skills, commands, and hooks
-├── docs/                # Guides, reference, and runbooks
-└── tests/               # Python and TypeScript-backed validation
-```
-
-The Python engine keeps validation, business logic, and command-line adapters
-separate so calculations remain testable outside an AI session. External
-providers are adapters around that engine, not the source of its financial
-math.
+CSV exports are enough to start. Power users can connect SnapTrade for
+read-only brokerage positions, balances, and transactions, and SimpleFIN for
+read-only bank and card activity. Both use credentials you obtain yourself and
+keep in local, gitignored files. The
+[live sync credentials guide](docs/setup/live-sync-credentials.md) lists the
+environment variables each provider needs and explains what
+`refresh_all` does with each leg.
 
 ## Data and privacy
 
-The repository's `.gitignore` covers environment files, common portfolio-export
-formats, user profiles, designated private directories, and local
-account-routing configuration. It cannot prevent an explicit force-add or
-protect an arbitrary output path. Before every push:
+The engine reads every private file from an instance directory outside the
+repository. The instance root comes from `FIN_GURU_DATA_ROOT`, or the current
+working directory when that variable is unset. The instance holds `.env`,
+`user-profile.yaml`, `config.yaml`, `system-context.md`, `family_office.db`,
+`snaptrade-accounts.yaml`, `dividend-schedules.yaml`, and the working
+directories `imports/`, `analysis/`, `tickets/`, `strategies/`, `hedging/`,
+`reports/`, `auto-tickets/`, and `notes/`.
 
-```bash
-git status --ignored
-git diff --cached
-git check-ignore .env
-```
+The repository is public. Tracked files describe behaviour and never carry
+personal values. The full rule and its enforcement live in
+[DataClassification](.claude/skills/compliance-scan/references/DataClassification.md)
+and [PRIVACY.md](PRIVACY.md).
 
-Use synthetic data in tests. Never commit account identifiers, balances,
-positions, API keys, or brokerage exports.
-
-Local-first does not mean network-free: market-data, brokerage, research, and
-LLM integrations may send request data to their configured providers. Review
-each provider's privacy terms and configure only the integrations you intend to
-use.
+Local-first does not mean network-free. Market data, brokerage, and LLM
+integrations send request data to their configured providers. Configure only
+the integrations you intend to use.
 
 ## Development
 
-The required Python gates mirror CI:
+The required Python gates mirror CI.
 
 ```bash
 uv sync --dev
 uv run ruff format --check .
 uv run ruff check .
 uv run mypy src/
-uv run pytest
+uv run pytest -m "not integration"
 ```
 
-Pull requests are accepted for documentation and the generic Python analysis
-engine. Other surfaces are issues-only while the standalone-app transition is
-underway. Read [Contributing](docs/CONTRIBUTING.md) before starting work.
+Read [Contributing](docs/CONTRIBUTING.md) before opening a pull request. It
+covers the accepted surfaces, the quality gates, and the privacy rules that
+every push must pass.
 
 ## Documentation
 
 | Document | Purpose |
 | --- | --- |
-| [GitHub Wiki](https://github.com/AojdevStudio/Finance-Guru/wiki) | Planned canonical guide; publication and rendered inspection are pending |
-| [Repository documentation](docs/index.md) | Current reader-facing setup, usage, architecture, privacy, contributor, and operational material |
+| [Repository documentation](docs/index.md) | Setup, usage, architecture, privacy, contributor, and operational material |
+| [Setup](docs/setup/SETUP.md) | Install the engine and create an instance |
 | [CLI reference](docs/reference/api.md) | Commands, arguments, and output |
+| [Live sync credentials](docs/setup/live-sync-credentials.md) | Bring-your-own-credentials setup for SnapTrade and SimpleFIN |
 | [API keys](docs/setup/api-keys.md) | Optional provider configuration |
 | [Troubleshooting](docs/setup/TROUBLESHOOTING.md) | Common installation and runtime failures |
 | [Runbooks](docs/runbooks/README.md) | Recurring portfolio and operations workflows |
-| [Vision](docs/VISION.md) | Standalone application direction and product decisions |
 | [Contributing](docs/CONTRIBUTING.md) | Accepted surfaces, review rules, and quality gates |
 
 ## License

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,27 +6,26 @@ category: root
 
 # Contributing to Finance Guru
 
-Thanks for looking. Read the *Project State* section below before investing time — it tells you which parts of this repo are worth contributing to and which are scheduled to be retired.
+Thanks for looking. Read the _Project State_ section below before investing time — it tells you which parts of this repo accept pull requests and which are issues-only for now.
 
 ---
 
 ## Project State (Read This First)
 
-Finance Guru is in the middle of a vision pivot. The project is transitioning from a Claude Code skill/hook/agent stack into a standalone macOS native application (Tauri v2 + Bun sidecar). See `docs/VISION.md` for the full rationale.
+Finance Guru is being converted, in place, into an installable Claude Code and Codex plugin. Everything ships open under AGPL-3.0. The skills, agents, and Python engine are all part of the product; there is no withheld feature tier.
 
 What this means for contributors today:
 
 
-| Area                                   | State                            | Safe to invest in?         |
-| -------------------------------------- | -------------------------------- | -------------------------- |
-| Python analysis engine (`src/`)        | **Stable, survives the pivot**   | *Yes*                      |
-| Claude Code skills (`.claude/skills/`) | **Transitional, likely retired** | No — file an issue instead |
-| BMAD-CORE agents (`fin-guru/agents/`)  | **Transitional, likely retired** | No — file an issue instead |
-| macOS app scaffold                     | **Does not exist yet**           | Not ready for contribution |
-| Documentation (`docs/`)                | **Always safe**                  | *Yes*                      |
+| Area                                   | State                                 | Safe to invest in?         |
+| -------------------------------------- | ------------------------------------- | -------------------------- |
+| Python analysis engine (`src/`)        | **Stable**                            | _Yes_                      |
+| Claude Code skills (`.claude/skills/`) | **Active, mid plugin conversion**     | No — file an issue instead |
+| BMAD-CORE agents (`fin-guru/agents/`)  | **Active, mid plugin conversion**     | No — file an issue instead |
+| Documentation (`docs/`)                | **Always safe**                       | _Yes_                      |
 
 
-If the thing you want to work on is labelled *transitional*, open an issue — do not open a PR against it. It will likely be deleted in the pivot, and we do not want you to waste effort.
+While the plugin conversion is underway, changes to skills, agents, and hooks start as issues, not PRs. The maintainer is actively reshaping those surfaces and parallel PRs against them will conflict.
 
 ---
 
@@ -45,7 +44,7 @@ If you want something built and you are not sure we will merge it, open an issue
 Only these surfaces are in scope for PRs:
 
 1. **Documentation** — Typo fixes, broken links, corrected API information, new MCP server entries in `docs/setup/api-keys.md`, clarified setup steps in `docs/setup/SETUP.md` and `TROUBLESHOOTING.md`, README polish.
-2. **Python analysis engine** — Generic calculators and utilities under `src/analysis/`, `src/strategies/`, `src/utils/`, and their corresponding tests under `tests/python/`. Examples: `correlation.py`, `backtester.py`, `momentum.py`, `risk_metrics.py`, `screener.py`, `volatility.py`, `market_data.py`. Path-coupled calculators accept `FIN_GURU_PRIVATE_DIR` / `FIN_GURU_PORTFOLIO_DIR` environment variables; contributors do not need access to the private data to work on them.
+2. **Python analysis engine** — Generic calculators and utilities under `src/analysis/`, `src/strategies/`, `src/utils/`, and their corresponding tests under `tests/python/`. Examples: `correlation.py`, `backtester.py`, `momentum.py`, `risk_metrics.py`, `screener.py`, `volatility.py`, `market_data.py`. Path-coupled calculators resolve every private file through `src/config/instance_paths.py`; contributors do not need access to private data to work on them.
 
 ### Issues only (no PRs)
 
@@ -56,7 +55,7 @@ Everything else is issues-only. We will evaluate bug reports and feature request
 - Hooks under `.claude/hooks/`
 - `finance-guru-desktop/` (Electron POC, gitignored)
 
-These surfaces are either deeply coupled to the private user profile or scheduled for replacement in the Tauri pivot.
+These surfaces are being reshaped by the plugin conversion, and outside PRs against them will conflict with that work.
 
 ---
 
@@ -64,7 +63,7 @@ These surfaces are either deeply coupled to the private user profile or schedule
 
 ### Marketing or promotional content in documentation
 
-PRs that swap neutral capability descriptions for vendor marketing copy (superlatives like "fastest," "most accurate," "best-in-class," or direct taglines from a vendor's homepage) are closed without merge. Documentation describes *what a tool does*, not *how good it is*.
+PRs that swap neutral capability descriptions for vendor marketing copy (superlatives like "fastest," "most accurate," "best-in-class," or direct taglines from a vendor's homepage) are closed without merge. Documentation describes _what a tool does_, not _how good it is_.
 
 Example of what we reject:
 
@@ -92,7 +91,15 @@ PRs that look AI-generated and carry no disclosure will be asked to either discl
 
 ### Changes to internal data or paths
 
-Anything gitignored is internal. Do not reference gitignored paths, account identifiers, dollar amounts, or the `fin-guru-private/` directory in code you submit. If you need test data, use synthetic data (numpy / fixtures) under `tests/python/`.
+Anything gitignored is internal. Do not reference gitignored paths, account identifiers, or dollar amounts in code you submit. If you need test data, use synthetic data (numpy / fixtures) under `tests/python/`.
+
+---
+
+## Data Classification (Public Repo Rule)
+
+This is a public repository, and every tracked file is published the moment it is pushed. Code and documentation describe behaviour and never carry personal values, so evidence is written as a shape (a ratio, a percentage, a count) rather than an amount. The full policy is [DataClassification](../.claude/skills/compliance-scan/references/DataClassification.md).
+
+Test fixtures use synthetic values that do not match the privacy scanner's patterns.
 
 ---
 
@@ -108,7 +115,7 @@ Anything gitignored is internal. Do not reference gitignored paths, account iden
 
 1. **Open an issue first.** Describe the bug or enhancement. Wait for acknowledgment before writing code. This protects you from investing in a PR we would reject.
 2. Fork the repo and create a feature branch.
-3. Make the change following the *Quality Gates* below.
+3. Make the change following the _Quality Gates_ below.
 4. Open a PR referencing the issue (`Fixes #N`).
 
 ---
@@ -131,6 +138,10 @@ Additionally:
 - **Three-layer pattern.** New financial tools follow the repo architecture: Pydantic input models in `src/models/`, calculator class in `src/analysis/` (or `strategies/` or `utils/`), CLI entry point as `{tool}_cli.py`. Reference implementation: `src/analysis/risk_metrics.py` + `src/models/risk_inputs.py` + `src/analysis/risk_metrics_cli.py`.
 
 See `src/CLAUDE.md` for conventions (Pydantic + pandas gotchas, naming, typing, docstrings).
+
+### Push gates
+
+Two gates run before anything reaches GitHub. The pre-commit hooks (`.pre-commit-config.yaml`) run hygiene checks, ruff, mypy, pytest with coverage, and gitleaks. The privacy scanner (`.claude/skills/compliance-scan/scripts/scan.py`) runs in its `push` scope from the pre-push hook and also supports a `history` scope that scans every line a branch adds. A HIGH or CRITICAL finding blocks the push.
 
 ---
 
@@ -179,4 +190,4 @@ Open an issue. Tag it `question`.
 
 ---
 
-*Last updated: 2026-04-17*
+_Last updated: 2026-09-02_

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ user-guide pages.
 | Install or develop the checked-in engine | [Setup](setup/SETUP.md) |
 | Find a verified command entry point | [CLI reference](reference/api.md) |
 | Configure optional provider credentials | [API keys](setup/api-keys.md) |
+| Connect SnapTrade or SimpleFIN live sync | [Live sync credentials](setup/live-sync-credentials.md) |
 | Resolve an environment or provider failure | [Troubleshooting](setup/TROUBLESHOOTING.md) |
 | Understand contribution boundaries and checks | [Contributing](CONTRIBUTING.md) |
 | Review data-handling boundaries | [Privacy](../PRIVACY.md) |

--- a/docs/setup/SETUP.md
+++ b/docs/setup/SETUP.md
@@ -34,6 +34,20 @@ The legacy `./setup.sh` scaffolds private-profile files and points to an
 unfinished onboarding flow. It is not part of the supported analysis-engine
 setup path.
 
+## Create an instance
+
+Private data lives in an instance directory outside the checkout. The engine
+resolves it from `FIN_GURU_DATA_ROOT` or the current working directory. Create
+one from the checkout:
+
+```bash
+uv run python -m src.cli.instance_init ~/finance-guru-data --repo .
+```
+
+The instance is a small uv project that depends on the engine, so
+`uv run python -m src.<tool>` works from inside it with no extra flags. Run
+Finance Guru sessions and sync commands from the instance directory.
+
 For the SimpleFIN workspace, install its Bun dependencies from that workspace:
 
 ```bash
@@ -55,20 +69,18 @@ uv run python src/analysis/risk_metrics_cli.py --help
 
 ## Configure credentials privately
 
-Copy the sample environment file only when you need an optional provider or a
-personal integration. Do not commit the resulting `.env` file.
-
-```bash
-cp .env.example .env
-```
+The instance scaffold writes a blank `.env` in the instance root. Fill in a
+variable only when you need an optional provider or a personal integration. Do
+not commit any `.env` file.
 
 See [API keys](api-keys.md) for the variables consumed by the supported
-integrations. Keep account exports, API keys, and database files out of Git.
+integrations and the
+[live sync credentials guide](live-sync-credentials.md) for SnapTrade and
+SimpleFIN. Keep account exports, API keys, and database files out of Git.
 
 ## Refresh local financial data
 
-The all-source refresh command must run as a module so Python can resolve the
-repository package imports:
+Run the all-source refresh from the instance directory:
 
 ```bash
 uv run python -m src.integrations.refresh_all --show

--- a/docs/setup/api-keys.md
+++ b/docs/setup/api-keys.md
@@ -6,23 +6,18 @@ category: setup
 
 # Finance Guru private configuration
 
-Keep credentials in a local `.env` file or process environment. `.env` and the
-local SQLite database are gitignored; that is a safeguard, not permission to
-print or commit their contents.
-
-Before running a supported data sync, create the root environment file from the
-checked-in sample. It supplies the required local database location even when
-you do not configure an external provider:
-
-```bash
-cp .env.example .env
-```
+Keep credentials in a local `.env` file or process environment. The engine
+reads `.env` from the instance root, the directory named by
+`FIN_GURU_DATA_ROOT` or the current working directory. `instance_init`
+scaffolds that file from the checked-in `.env.example` with every value blank.
+The `.env` file and the local SQLite database are gitignored; that is a
+safeguard, not permission to print or commit their contents.
 
 ## Local data store
 
 | Variable | Purpose | Default behavior |
 | --- | --- | --- |
-| `DATABASE_URL` | SQLite connection URL used by the supported sync modules. | Required; the checked-in sample sets `sqlite:///family_office.db`. |
+| `DATABASE_URL` | SQLite connection URL used by the supported sync modules. | Optional; defaults to `family_office.db` under the instance root. |
 
 The standard local database filename is `family_office.db`. Do not point a
 public example or CI job at a real database.
@@ -39,9 +34,10 @@ contact the provider:
 | `SNAPTRADE_USER_ID` | Linked user identifier. |
 | `SNAPTRADE_USER_SECRET` | Linked user secret. |
 
-Account roles and enabled-state are stored separately in the local
-`config/snaptrade-accounts.yaml` file after account discovery. Do not commit
-that file when it contains personal routing information.
+Account roles and enabled-state are stored separately in
+`snaptrade-accounts.yaml` under the instance root after account discovery. See
+the [live sync credentials guide](live-sync-credentials.md) for the discovery
+command and the routing rules.
 
 ## SimpleFIN
 

--- a/docs/setup/live-sync-credentials.md
+++ b/docs/setup/live-sync-credentials.md
@@ -1,0 +1,89 @@
+---
+title: "Live sync credentials"
+description: "Bring-your-own-credentials setup for SnapTrade and SimpleFIN live sync"
+category: setup
+---
+
+# Live sync credentials
+
+Finance Guru works CSV-first. Live sync is optional. It connects two read-only
+providers, SnapTrade for brokerage data and SimpleFIN for bank and card
+activity. You obtain the credentials yourself and keep them in local,
+gitignored files. This guide names the variables each provider needs. Never
+write a credential value into a tracked file, an issue, or a pull request.
+
+## Where the `.env` lives
+
+The engine loads `.env` from the instance root, the directory named by
+`FIN_GURU_DATA_ROOT` or the current working directory. `instance_init` scaffolds
+that file from `.env.example` with every variable left blank. Edit the
+instance's `.env`, not a copy inside the repository checkout.
+
+## SnapTrade
+
+SnapTrade supplies brokerage positions, balances, and transactions. The
+integration is read-only and requires four variables in the instance `.env`.
+
+| Variable | Purpose |
+| --- | --- |
+| `SNAPTRADE_CLIENT_ID` | SnapTrade application client identifier |
+| `SNAPTRADE_CONSUMER_KEY` | SnapTrade consumer key |
+| `SNAPTRADE_USER_ID` | Linked user identifier |
+| `SNAPTRADE_USER_SECRET` | Linked user secret |
+
+All four must be present. The credential loader in
+`src/integrations/snaptrade/models.py` raises an error naming any missing
+variable.
+
+### Account routing
+
+Sync only touches accounts you have explicitly enabled. The routing file is
+`snaptrade-accounts.yaml` in the instance root. Generate it from your linked
+accounts.
+
+```bash
+uv run python -m src.integrations.snaptrade.cli accounts --write-config
+```
+
+Then edit the file. Give each account a `role` and set `enabled: true` only
+after you have verified the account against a broker export. Accounts left
+`unassigned` or disabled never sync.
+
+## SimpleFIN
+
+SimpleFIN supplies bank and card transactions. The credentials are consumed by
+the Bun workspace under `apps/simplefin-sync/`, which reads its own `.env` in
+that directory, not the instance `.env`.
+
+| Variable | Purpose |
+| --- | --- |
+| `SIMPLEFIN_SETUP_TOKEN` | One-time token exchanged by the claim command |
+| `SIMPLEFIN_ACCESS_URL` | Long-lived access URL used for account reads |
+| `SIMPLEFIN_TRIGGER_INTERVAL_MS` | Optional poll interval for the local deposit-trigger process |
+
+Claim the setup token once. The claim command writes the resulting access URL
+into `apps/simplefin-sync/.env` and refuses to overwrite an existing one.
+
+```bash
+cd apps/simplefin-sync
+cp .env.example .env
+# Set SIMPLEFIN_SETUP_TOKEN in apps/simplefin-sync/.env before continuing.
+bun run claim
+```
+
+Treat both the setup token and the access URL as credentials.
+
+## What `refresh_all` does
+
+`uv run python -m src.integrations.refresh_all` runs three legs in order, each
+isolated from the others.
+
+| Leg | Source | What it writes |
+| --- | --- | --- |
+| `positions` | SnapTrade | Positions and balances for config-enabled accounts into `family_office.db` |
+| `transactions` | SnapTrade | Investment activities, including dividends, into the transactions table |
+| `expenses` | SimpleFIN | Bank and card transactions, auto-categorized, into the bank transactions table |
+
+A failed leg does not stop the others. The command exits non-zero when any leg
+fails, so automation can detect a stale source. Run with `--show` to print the
+synced tables without contacting either provider.


### PR DESCRIPTION
## Why

Wayfinder #131, phase P4. The README spoke to the owner. It now speaks to a technical operator who found the repository, with the positions locked in #131: everything open under AGPL, Finance Guru as the free CLI-native experience and Keepfolio as the polished product, CSV-first with live sync as bring-your-own-credentials.

## Scope

- `README.md`: what it is, the Keepfolio line, a checkout quick start to a first `refresh_all --show`, an install-as-plugin section labelled as landing with the plugin release, a what-you-get table, live sync, data and privacy, development, documentation, license, disclaimer. Retired surfaces removed.
- `docs/setup/live-sync-credentials.md`: SnapTrade and SimpleFIN variables by name, where the `.env` lives, and how to write the routing file.
- `docs/CONTRIBUTING.md`: the DataClassification rule, the push gates, and the synthetic-fixture rule; the stale Tauri project-state text replaced with the #131 positioning.
- `docs/setup/SETUP.md`, `docs/setup/api-keys.md`, `docs/index.md`: paths and pointers updated.

## Tradeoffs

Keepfolio is named without a link because no Keepfolio URL exists in the repo today. SimpleFIN credentials are documented at `apps/simplefin-sync/.env`, where the sync actually reads them.

## Verification

- The quick start was run from a fresh clone of main into a scratch instance; each command's tail is in the lane report.
- `rg` for retired surface names across the edited files prints nothing. Markdownlint passes.

Refs #131.

Written by a Claude Fable 5 lane on dev-substrate from a written brief; reviewed and committed by Claude Fable 5.1 running in Claude Code as the program coordinator.