### PR TITLE
fix(instance): scrub placeholder env values and run chart tools as modules

### DIFF
--- a/.claude/skills/FinanceReport/VisGuide.md
+++ b/.claude/skills/FinanceReport/VisGuide.md
@@ -176,18 +176,19 @@ def create_embedded_chart(data, chart_type, title):
 ```python
 import subprocess
 import json
+import sys
 
-def get_chart_data(ticker, tool, days=90):
+def get_chart_data(ticker, module, days=90):
     """Run CLI tool and parse JSON output for charting."""
     result = subprocess.run(
-        ['uv', 'run', 'python', f'src/analysis/{tool}.py', ticker, '--days', str(days), '--output', 'json'],
+        [sys.executable, '-m', module, ticker, '--days', str(days), '--output', 'json'],
         capture_output=True, text=True
     )
     return json.loads(result.stdout)
 
 # Example usage
-risk_data = get_chart_data('TSLA', 'risk_metrics_cli', 252)
-momentum_data = get_chart_data('TSLA', 'momentum_cli', 90)
+risk_data = get_chart_data('TSLA', 'src.analysis.risk_metrics_cli', 252)
+momentum_data = get_chart_data('TSLA', 'src.utils.momentum_cli', 90)
 ```
 
 ## Accessibility Notes

--- a/.claude/skills/FinanceReport/tools/ChartKit.py
+++ b/.claude/skills/FinanceReport/tools/ChartKit.py
@@ -47,17 +47,17 @@ COLORS = {
 }
 
 
-def run_cli_tool(tool_path: str, args: list[str]) -> dict[str, Any]:
+def run_cli_tool(module_name: str, args: list[str]) -> dict[str, Any]:
     """Run a Finance Guru CLI tool and parse JSON output."""
-    cmd = ["uv", "run", "python", tool_path] + args + ["--output", "json"]
+    cmd = [sys.executable, "-m", module_name] + args + ["--output", "json"]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
     except subprocess.CalledProcessError as e:
-        print(f"Error running {tool_path}: {e.stderr}")
+        print(f"Error running {module_name}: {e.stderr}")
         return {}
     except json.JSONDecodeError:
-        print(f"Error parsing JSON from {tool_path}")
+        print(f"Error parsing JSON from {module_name}")
         return {}
 
 
@@ -317,7 +317,7 @@ Examples:
         else:
             # Use momentum CLI to get price data
             data = run_cli_tool(
-                "src/utils/momentum_cli.py", [args.ticker, "--days", str(args.days)]
+                "src.utils.momentum_cli", [args.ticker, "--days", str(args.days)]
             )
 
         title = args.title or f"{args.ticker} - {args.days} Day Price History"
@@ -329,7 +329,7 @@ Examples:
         else:
             # Use risk metrics CLI
             data = run_cli_tool(
-                "src/analysis/risk_metrics_cli.py", [args.ticker, "--days", "252"]
+                "src.analysis.risk_metrics_cli", [args.ticker, "--days", "252"]
             )
 
         title = args.title or f"{args.ticker} - Risk Metrics"
@@ -342,9 +342,7 @@ Examples:
         tickers = args.tickers.split(",") if args.tickers else [args.ticker]
 
         # Use correlation CLI
-        data = run_cli_tool(
-            "src/analysis/correlation_cli.py", tickers + ["--days", "252"]
-        )
+        data = run_cli_tool("src.analysis.correlation_cli", tickers + ["--days", "252"])
 
         title = args.title or "Correlation Matrix"
         buffer = create_heatmap(
@@ -360,7 +358,7 @@ Examples:
             data = json.loads(args.data)
         else:
             data = run_cli_tool(
-                "src/utils/momentum_cli.py", [args.ticker, "--days", str(args.days)]
+                "src.utils.momentum_cli", [args.ticker, "--days", str(args.days)]
             )
 
         title = args.title or f"{args.ticker} - Technical Analysis"

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,19 +8,19 @@ Finance Guru is a **private, single-user family-office system**. This document d
 
 - All financial data stays on the owner's machine
 - No telemetry, no remote analytics, no third-party data sharing
-- Nothing personally identifying is committed to git — enforced by `.gitignore` and the `compliance-scan` skill
+- Nothing personally identifying is committed to the public engine repository; the separate instance repository is local-only and has no remote
 - When data _does_ leave the laptop (SnapTrade, SimpleFIN, Fidelity APIs, ITC Risk Models), it goes directly to the owner's own accounts — no intermediary
 
 ## What data Finance Guru handles
 
 | Category | Source | Storage | Exposure |
 | ---------- | -------- | --------- | ---------- |
-| Portfolio positions | SnapTrade (CSV fallback) | `family_office.db` (gitignored) | Local only |
-| Account balances | SnapTrade (CSV fallback) | `family_office.db` (gitignored) | Local only |
-| Transaction history | SnapTrade | `family_office.db` (gitignored) | Local only |
-| Bank / card spending | SimpleFIN | `family_office.db` (gitignored) | Local only |
-| Dividend events | SnapTrade activities | `family_office.db` (gitignored) | Local only |
-| User profile (risk tolerance, goals) | Interactive onboarding | `fin-guru/data/user-profile.yaml` (gitignored) | Local only |
+| Portfolio positions | SnapTrade (CSV fallback) | `family_office.db` (committed to local-only instance repository) | Local only; no remote |
+| Account balances | SnapTrade (CSV fallback) | `family_office.db` (committed to local-only instance repository) | Local only; no remote |
+| Transaction history | SnapTrade | `family_office.db` (committed to local-only instance repository) | Local only; no remote |
+| Bank / card spending | SimpleFIN | `family_office.db` (committed to local-only instance repository) | Local only; no remote |
+| Dividend events | SnapTrade activities | `family_office.db` (committed to local-only instance repository) | Local only; no remote |
+| User profile (risk tolerance, goals) | Interactive onboarding | `user-profile.yaml` under the instance root (committed to local-only instance repository) | Local only; no remote |
 | Market data | yfinance / Finnhub / ITC | In-memory during analysis | Per-provider terms |
 
 ## What leaves your machine

--- a/docs/setup/SETUP.md
+++ b/docs/setup/SETUP.md
@@ -7,8 +7,9 @@ category: setup
 # Finance Guru setup
 
 This guide installs the checked-in Python and Bun workspaces. The supported
-data store is the local, gitignored `family_office.db`; Google Sheets is not a
-data source and no Google Drive integration is required.
+data store is the local `family_office.db`, committed only to the instance's
+local-only repository; Google Sheets is not a data source and no Google Drive
+integration is required.
 
 ## Prerequisites
 

--- a/docs/setup/SETUP.md
+++ b/docs/setup/SETUP.md
@@ -69,14 +69,17 @@ uv run python src/analysis/risk_metrics_cli.py --help
 
 ## Configure credentials privately
 
-The instance scaffold writes a blank `.env` in the instance root. Fill in a
-variable only when you need an optional provider or a personal integration. Do
-not commit any `.env` file.
+The instance scaffold writes an `.env` in the instance root that keeps real
+defaults and comments out credentials for you to fill in. Uncomment a variable
+only when you need an optional provider or a personal integration. Do not commit
+any `.env` file.
 
 See [API keys](api-keys.md) for the variables consumed by the supported
 integrations and the
 [live sync credentials guide](live-sync-credentials.md) for SnapTrade and
-SimpleFIN. Keep account exports, API keys, and database files out of Git.
+SimpleFIN. Keep account exports, API keys, and database files out of the public
+engine checkout. The database is committed only to the instance's local-only
+repository, which has no remote.
 
 ## Refresh local financial data
 

--- a/docs/setup/api-keys.md
+++ b/docs/setup/api-keys.md
@@ -9,9 +9,11 @@ category: setup
 Keep credentials in a local `.env` file or process environment. The engine
 reads `.env` from the instance root, the directory named by
 `FIN_GURU_DATA_ROOT` or the current working directory. `instance_init`
-scaffolds that file from the checked-in `.env.example` with every value blank.
-The `.env` file and the local SQLite database are gitignored; that is a
-safeguard, not permission to print or commit their contents.
+scaffolds that file from the checked-in `.env.example`, preserving real defaults
+and commenting out empty values and credential placeholders for you to fill in.
+The `.env` file is gitignored. The local SQLite database is committed to the
+instance's local-only repository, which has no remote, and never to the public
+engine checkout.
 
 ## Local data store
 
@@ -90,11 +92,10 @@ but a provider may still receive the tickers you query. See [Privacy](../../PRIV
 
 ## Test safety
 
-Do not leave `.env.example` placeholders in a local `.env` while running the
-test suite. Some configuration loaders parse numeric values at import time, so
-placeholder text can fail tests before the test's actual behavior is reached.
-For a clean local test run, remove the scaffolded `.env` or replace only the
-values you intentionally use:
+The instance initializer comments out `.env.example` placeholders so they do
+not enter the process environment. If you copy `.env.example` manually instead,
+comment out unused placeholders before running tests; some configuration loaders
+parse numeric values at import time and reject placeholder text:
 
 ```bash
 uv run pytest -m "not integration"

--- a/docs/setup/live-sync-credentials.md
+++ b/docs/setup/live-sync-credentials.md
@@ -16,8 +16,9 @@ write a credential value into a tracked file, an issue, or a pull request.
 
 The engine loads `.env` from the instance root, the directory named by
 `FIN_GURU_DATA_ROOT` or the current working directory. `instance_init` scaffolds
-that file from `.env.example` with every variable left blank. Edit the
-instance's `.env`, not a copy inside the repository checkout.
+that file from `.env.example`, preserving real defaults and commenting out empty
+values and credential placeholders. Edit the instance's `.env`, not a copy
+inside the repository checkout.
 
 ## SnapTrade
 
@@ -51,9 +52,12 @@ after you have verified the account against a broker export. Accounts left
 
 ## SimpleFIN
 
-SimpleFIN supplies bank and card transactions. The credentials are consumed by
-the Bun workspace under `apps/simplefin-sync/`, which reads its own `.env` in
-that directory, not the instance `.env`.
+SimpleFIN supplies bank and card transactions. The recommended single location
+for its long-lived credential is the instance `.env`. `refresh_all` loads that
+file with override enabled before it starts Bun in `apps/simplefin-sync/`, so an
+uncommented `SIMPLEFIN_ACCESS_URL` in the instance `.env` wins. Bun reads the
+workspace's `apps/simplefin-sync/.env` value only when the instance leaves
+`SIMPLEFIN_ACCESS_URL` commented out.
 
 | Variable | Purpose |
 | --- | --- |
@@ -62,7 +66,9 @@ that directory, not the instance `.env`.
 | `SIMPLEFIN_TRIGGER_INTERVAL_MS` | Optional poll interval for the local deposit-trigger process |
 
 Claim the setup token once. The claim command writes the resulting access URL
-into `apps/simplefin-sync/.env` and refuses to overwrite an existing one.
+into `apps/simplefin-sync/.env` and refuses to overwrite an existing one. To use
+the recommended single location afterward, move that value to the instance
+`.env`, uncomment `SIMPLEFIN_ACCESS_URL`, and comment out the workspace copy.
 
 ```bash
 cd apps/simplefin-sync

--- a/src/cli/instance_init.py
+++ b/src/cli/instance_init.py
@@ -103,6 +103,15 @@ def _run_git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _reject_git_remotes(root: Path) -> None:
+    remote_names = _run_git(root, "remote").stdout.splitlines()
+    if remote_names:
+        names = ", ".join(remote_names)
+        raise RuntimeError(
+            f"{root} has git remote(s): {names}; the instance must have no remote"
+        )
+
+
 def _initialize_git(path: Path) -> StepResult:
     existed = path.exists()
     root = path.parent
@@ -115,6 +124,7 @@ def _initialize_git(path: Path) -> StepResult:
             env=_git_env(),
         )
 
+    _reject_git_remotes(root)
     commit_count = int(_run_git(root, "rev-list", "--count", "--all").stdout)
     if commit_count == 0:
         _run_git(root, "add", "-A")
@@ -141,13 +151,22 @@ def _instance_env(example: str) -> str:
             continue
 
         key, value = line.split("=", 1)
+        normalized_value = value.strip()
+        if (
+            len(normalized_value) >= 2
+            and normalized_value[0] == normalized_value[-1]
+            and normalized_value[0] in {'"', "'"}
+        ):
+            normalized_value = normalized_value[1:-1]
+
         if key == "FIN_GURU_DATA_ROOT":
             value = ""
             found_data_root = True
         elif (
-            "your_" in value
-            or value.endswith("_here")
-            or (value.startswith("${") and value.endswith("}"))
+            not normalized_value
+            or "your_" in normalized_value
+            or normalized_value.endswith("_here")
+            or (normalized_value.startswith("${") and normalized_value.endswith("}"))
         ):
             value = ""
 
@@ -267,6 +286,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     paths = InstancePaths(root=args.root.expanduser().resolve())
     repo = args.repo.expanduser().resolve()
+
+    if (paths.root / ".git").exists():
+        _reject_git_remotes(paths.root)
 
     for step in _build_plan(paths, repo):
         result = step.action(step.target)

--- a/src/cli/instance_init.py
+++ b/src/cli/instance_init.py
@@ -133,13 +133,28 @@ def _initialize_git(path: Path) -> StepResult:
 
 
 def _instance_env(example: str) -> str:
-    lines = example.splitlines()
-    for index, line in enumerate(lines):
-        if line.startswith("FIN_GURU_DATA_ROOT="):
-            lines[index] = "FIN_GURU_DATA_ROOT="
-            break
-    else:
-        lines.append("FIN_GURU_DATA_ROOT=")
+    lines: list[str] = []
+    found_data_root = False
+    for line in example.splitlines():
+        if line.lstrip().startswith("#") or "=" not in line:
+            lines.append(line)
+            continue
+
+        key, value = line.split("=", 1)
+        if key == "FIN_GURU_DATA_ROOT":
+            value = ""
+            found_data_root = True
+        elif (
+            "your_" in value
+            or value.endswith("_here")
+            or (value.startswith("${") and value.endswith("}"))
+        ):
+            value = ""
+
+        lines.append(f"{key}={value}" if value else f"# {key}=")
+
+    if not found_data_root:
+        lines.append("# FIN_GURU_DATA_ROOT=")
     return "\n".join(lines) + "\n"
 
 

--- a/tests/python/test_instance_init.py
+++ b/tests/python/test_instance_init.py
@@ -181,9 +181,9 @@ def test_fresh_root_creates_complete_instance(tmp_path: Path) -> None:
     assert (root / ".git").is_dir()
 
     env_lines = paths.env_file.read_text(encoding="utf-8").splitlines()
-    assert "FIN_GURU_DATA_ROOT=" in env_lines
+    assert "# FIN_GURU_DATA_ROOT=" in env_lines
     assert "FIN_GURU_DATA_ROOT=/replace/me" not in env_lines
-    assert "EXAMPLE_SETTING=" in env_lines
+    assert "# EXAMPLE_SETTING=" in env_lines
 
     profile = yaml.safe_load(paths.profile.read_text(encoding="utf-8"))
     assert set(profile) == {
@@ -208,6 +208,38 @@ def test_fresh_root_creates_complete_instance(tmp_path: Path) -> None:
     assert _git(root, "rev-list", "--count", "HEAD") == "1"
     assert _git(root, "log", "-1", "--format=%s") == "scaffold instance"
     assert _git(root, "remote") == ""
+
+
+def test_scaffolded_env_comments_empty_and_placeholder_values(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    (repo / ".env.example").write_text(
+        "FIN_GURU_DATA_ROOT=/replace/me\n"
+        "SIMPLEFIN_ACCESS_URL=\n"
+        "SNAPTRADE_CLIENT_ID=your_snaptrade_client_id_here\n"
+        "SIMPLEFIN_SETUP_TOKEN=${SIMPLEFIN_SETUP_TOKEN}\n"
+        "LEGACY_SECRET=credential_here\n"
+        "SMTP_PORT=587\n"
+        "DEFAULT_RISK_TOLERANCE=aggressive\n"
+        "DATABASE_URL=sqlite:///family_office.db\n",
+        encoding="utf-8",
+    )
+    root = tmp_path / "instance"
+
+    result = _run_init(root, repo)
+
+    assert result.returncode == 0, result.stderr
+    env_text = (root / ".env").read_text(encoding="utf-8")
+    env_lines = env_text.splitlines()
+    assert "_here" not in env_text
+    assert "your_" not in env_text
+    assert env_lines.count("# SIMPLEFIN_ACCESS_URL=") == 1
+    assert not any(line.startswith("SIMPLEFIN_ACCESS_URL=") for line in env_lines)
+    assert "# SNAPTRADE_CLIENT_ID=" in env_lines
+    assert "# SIMPLEFIN_SETUP_TOKEN=" in env_lines
+    assert "# LEGACY_SECRET=" in env_lines
+    assert "SMTP_PORT=587" in env_lines
+    assert "DEFAULT_RISK_TOLERANCE=aggressive" in env_lines
+    assert "DATABASE_URL=sqlite:///family_office.db" in env_lines
 
 
 def test_second_run_is_a_no_op(tmp_path: Path) -> None:

--- a/tests/python/test_instance_init.py
+++ b/tests/python/test_instance_init.py
@@ -210,11 +210,15 @@ def test_fresh_root_creates_complete_instance(tmp_path: Path) -> None:
     assert _git(root, "remote") == ""
 
 
-def test_scaffolded_env_comments_empty_and_placeholder_values(tmp_path: Path) -> None:
+@pytest.mark.parametrize("empty_value", ['""', "''", "   "])
+def test_scaffolded_env_comments_empty_and_placeholder_values(
+    tmp_path: Path, empty_value: str
+) -> None:
     repo = _fake_repo(tmp_path)
     (repo / ".env.example").write_text(
         "FIN_GURU_DATA_ROOT=/replace/me\n"
         "SIMPLEFIN_ACCESS_URL=\n"
+        f"QUOTED_OR_BLANK_SETTING={empty_value}\n"
         "SNAPTRADE_CLIENT_ID=your_snaptrade_client_id_here\n"
         "SIMPLEFIN_SETUP_TOKEN=${SIMPLEFIN_SETUP_TOKEN}\n"
         "LEGACY_SECRET=credential_here\n"
@@ -234,6 +238,8 @@ def test_scaffolded_env_comments_empty_and_placeholder_values(tmp_path: Path) ->
     assert "your_" not in env_text
     assert env_lines.count("# SIMPLEFIN_ACCESS_URL=") == 1
     assert not any(line.startswith("SIMPLEFIN_ACCESS_URL=") for line in env_lines)
+    assert env_lines.count("# QUOTED_OR_BLANK_SETTING=") == 1
+    assert not any(line.startswith("QUOTED_OR_BLANK_SETTING=") for line in env_lines)
     assert "# SNAPTRADE_CLIENT_ID=" in env_lines
     assert "# SIMPLEFIN_SETUP_TOKEN=" in env_lines
     assert "# LEGACY_SECRET=" in env_lines
@@ -272,6 +278,35 @@ def test_existing_profile_is_preserved_byte_for_byte(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert profile.read_bytes() == original
     assert f"exists {profile}" in result.stdout.splitlines()
+
+
+def test_existing_repo_with_remote_is_rejected_before_scaffolding(
+    tmp_path: Path,
+) -> None:
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            name: value
+            for name, value in os.environ.items()
+            if not name.startswith("GIT_")
+        },
+    )
+    _git(root, "remote", "add", "origin", str(remote))
+
+    result = _run_init(root, repo)
+
+    assert result.returncode != 0
+    assert str(root) in result.stderr
+    assert "origin" in result.stderr
+    assert "must have no remote" in result.stderr
+    assert {path.name for path in root.iterdir()} == {".git"}
+    assert _git(root, "rev-list", "--count", "--all") == "0"
 
 
 def test_real_claude_directory_fails_and_names_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Review threads on #143 and #146 found five real gaps. The scaffolded instance `.env` copied the example's placeholder credentials, which pass the missing-credential check, and its empty `SIMPLEFIN_ACCESS_URL` shadowed the workspace file because `refresh_all` loads the instance file with `override=True`. The FinanceReport chart tool still shelled out to engine scripts by file path, which does not exist from an instance cwd. `PRIVACY.md` and two setup guides misstated where the profile lives and whether the database is ignored.

## Scope

- `src/cli/instance_init.py`: placeholder and empty values in the scaffolded `.env` are written as commented keys; real defaults stay. Regression test added.
- `.claude/skills/FinanceReport/tools/ChartKit.py` and `VisGuide.md`: the subprocess contract takes module names and runs them through `sys.executable -m`.
- `PRIVACY.md`, `docs/setup/api-keys.md`, `docs/setup/SETUP.md`, `docs/setup/live-sync-credentials.md`: the profile and database live in the instance's local-only repository, which has no remote; the scaffolded `.env` keeps defaults and comments out credentials; the instance `.env` is the recommended single SimpleFIN location, with the workspace file as fallback when the variable stays commented.

## Verification

- The new scaffold test failed before and passes after. Full non-integration suite: 1110 passed, coverage 81.5%. ruff and mypy clean.
- A scratch instance scaffolded from this branch has no placeholder values and `SIMPLEFIN_ACCESS_URL` commented; a ChartKit line chart rendered from that instance.
- A sentinel test of Bun's precedence confirmed the documented order: inherited instance value wins, workspace file is the fallback.

Refs #131.

Built by a codex lane (gpt-5.6-sol, xhigh) on dev-substrate from a written brief; reviewed and committed by Claude Fable 5.1 running in Claude Code as the program coordinator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Instance setup now preserves real default settings while commenting out empty or placeholder credentials.
  - Chart-generation tools now support fully qualified Python module names.

- **Documentation**
  - Updated setup guidance explains credential handling, environment variable precedence, and local-only database storage.
  - Updated privacy information clarifies that sensitive instance data remains local and is not remotely exposed.
  - Added guidance for moving live-sync credentials into the instance environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->