### PR TITLE
ci: pin workflow token permissions and skip Claude review for Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,9 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
+    # Dependabot-triggered runs have no repository secrets, so the OAuth
+    # token is empty and the action fails before reviewing anything.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -9,6 +9,9 @@ concurrency:
   group: quality-gates-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   dead-code-vulture:
     name: Dead-code scan (vulture)

--- a/.github/workflows/validate-agents-md.yml
+++ b/.github/workflows/validate-agents-md.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/validate-agents-md.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Lint AGENTS.md + CLAUDE.md


### PR DESCRIPTION
## Problem

CodeQL raises ten `actions/missing-workflow-permissions` warnings across `ci.yml`, `quality-gates.yml`, and `validate-agents-md.yml`. Separately, the Claude Code Review job fails on every Dependabot PR because bot-triggered runs receive no repository secrets, so the OAuth token is empty.

## Fix

Declare `permissions: contents: read` at the workflow level in the three flagged files (no job in them writes to the repo; the coverage badge step only produces a file). Guard the Claude review job with `if: github.actor != 'dependabot[bot]'`.

actionlint reports only pre-existing SC2129 style notes, none on the changed lines.

Closes CodeQL alerts 1 through 10.

Changes made by Claude Fable 5.1 in Claude Code.