### PR TITLE
fix(simplefin): fail partial syncs loudly and gate the deposit trigger on settled transactions

### DIFF
--- a/apps/simplefin-sync/src/dump.test.ts
+++ b/apps/simplefin-sync/src/dump.test.ts
@@ -1,0 +1,38 @@
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+async function runDump(months: string): Promise<{
+  exitCode: number;
+  stderr: string;
+}> {
+  const proc = Bun.spawn([process.execPath, "run", path.join(import.meta.dir, "dump.ts"), months], {
+    cwd: path.resolve(import.meta.dir, ".."),
+    env: {
+      ...process.env,
+      SIMPLEFIN_ACCESS_URL: "invalid-for-months-test",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stderr).text(),
+  ]);
+  return { exitCode, stderr };
+}
+
+describe("SimpleFIN dump CLI", () => {
+  test.each(["not-a-number", "0", "-1", "1.5", "121"])(
+    "rejects invalid months value %s before creating the client",
+    async (months) => {
+      const result = await runDump(months);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        `months must be a whole number between 1 and 120, got "${months}"`,
+      );
+      expect(result.stderr).not.toContain("SIMPLEFIN_ACCESS_URL");
+    },
+  );
+});

--- a/apps/simplefin-sync/src/dump.ts
+++ b/apps/simplefin-sync/src/dump.ts
@@ -7,13 +7,21 @@
  */
 import { createClient, toSfinTimestamp } from "./client";
 
+const MAX_MONTHS = 120;
 const accessUrl = process.env.SIMPLEFIN_ACCESS_URL?.trim();
 if (!accessUrl) {
   console.error("✗ SIMPLEFIN_ACCESS_URL is empty. Run `bun run claim` first.");
   process.exit(1);
 }
 
-const months = Number(process.argv[2] ?? 12);
+const monthsArgument = process.argv[2] ?? "12";
+const months = Number(monthsArgument);
+if (!Number.isInteger(months) || months < 1 || months > MAX_MONTHS) {
+  console.error(
+    `✗ months must be a whole number between 1 and ${MAX_MONTHS}, got "${monthsArgument}"`,
+  );
+  process.exit(1);
+}
 const startDate = toSfinTimestamp(
   new Date(Date.now() - months * 31 * 24 * 60 * 60 * 1000),
 );

--- a/apps/simplefin-sync/src/trigger.test.ts
+++ b/apps/simplefin-sync/src/trigger.test.ts
@@ -63,6 +63,41 @@ describe("SimpleFIN deposit trigger", () => {
     expect(detections[0].sourceAccountKey).not.toContain("account-default");
   });
 
+  test("filters unsettled deposits before detection", async () => {
+    const seenStore = createMemorySeenStore();
+    const { detections, skippedDuplicates } = await findNewDepositDetections(
+      accountSet([
+        transaction({
+          id: "tx-pending",
+          amount: "5000.00",
+          posted: 1_779_984_000,
+          pending: true,
+        }),
+        transaction({
+          id: "tx-zero-posted",
+          amount: "4500.00",
+          posted: 0,
+          pending: false,
+        }),
+        transaction({
+          id: "tx-settled",
+          amount: "3100.00",
+          posted: 1_779_984_000,
+          pending: false,
+        }),
+      ]),
+      seenStore,
+    );
+
+    expect(skippedDuplicates).toBe(0);
+    expect(detections).toHaveLength(1);
+    expect(detections[0]).toMatchObject({
+      amount: "3100.00",
+      posted: 1_779_984_000,
+      pending: false,
+    });
+  });
+
   test("suppresses duplicate transaction ids within a single poll response", async () => {
     const seenStore = createMemorySeenStore();
     const { detections, skippedDuplicates } = await findNewDepositDetections(

--- a/apps/simplefin-sync/src/trigger.ts
+++ b/apps/simplefin-sync/src/trigger.ts
@@ -21,7 +21,7 @@ export interface DepositDetection {
   sourceAccountKey: string;
   amount: string;
   posted: number;
-  pending: boolean;
+  pending: false;
 }
 
 export interface TriggerResult {
@@ -175,6 +175,14 @@ export function isDepositOverThreshold(
   return amount > thresholdUnits;
 }
 
+export function isSettledTransaction(transaction: SfinTransaction): boolean {
+  return (
+    transaction.pending !== true &&
+    Number.isSafeInteger(transaction.posted) &&
+    transaction.posted > 0
+  );
+}
+
 function stableKey(...parts: string[]): string {
   return createHash("sha256").update(parts.join("\u001f")).digest("hex").slice(0, 16);
 }
@@ -184,13 +192,14 @@ export function detectionFromTransaction(
   transaction: SfinTransaction,
   threshold = DEFAULT_THRESHOLD,
 ): DepositDetection | null {
+  if (!isSettledTransaction(transaction)) return null;
   if (!isDepositOverThreshold(transaction, threshold)) return null;
   return {
     transactionKey: stableKey(account.id, transaction.id),
     sourceAccountKey: stableKey(account.id),
     amount: transaction.amount,
     posted: transaction.posted,
-    pending: transaction.pending ?? false,
+    pending: false,
   };
 }
 

--- a/src/integrations/simplefin/sync_expenses_db.py
+++ b/src/integrations/simplefin/sync_expenses_db.py
@@ -237,6 +237,13 @@ def sync(
     accounts = payload.get("accounts") or []
     errors = payload.get("errors") or []
     errlist = payload.get("errlist") or []
+    partial_errors = len(errors) + len(errlist)
+    if partial_errors:
+        details = "; ".join(str(item) for item in [*errors, *errlist])
+        raise SimpleFinSyncError(
+            f"SimpleFIN reported {partial_errors} partial account error(s); "
+            f"sync aborted: {details}"
+        )
     rows: list[tuple[Any, ...]] = []
     transactions_seen = 0
     skipped_missing_id = 0
@@ -279,7 +286,7 @@ def sync(
         "inserted": inserted,
         "updated": updated,
         "skipped_missing_id": skipped_missing_id,
-        "partial_errors": len(errors) + len(errlist),
+        "partial_errors": partial_errors,
         "by_category": by_category,
     }
 

--- a/tests/python/test_simplefin_expenses.py
+++ b/tests/python/test_simplefin_expenses.py
@@ -2,12 +2,15 @@ import sqlite3
 from copy import deepcopy
 from pathlib import Path
 
+import pytest
+
 from src.integrations.simplefin import sync_expenses_db
 from src.integrations.simplefin.categorize import (
     NON_SPEND_CATEGORIES,
     categorize_expense,
 )
 from src.integrations.simplefin.sync_expenses_db import (
+    SimpleFinSyncError,
     normalize_transaction,
     resolve_direction,
     sync,
@@ -143,6 +146,29 @@ def test_sync_inserts_updates_and_promotes_pending_transaction(tmp_path) -> None
         count = conn.execute("SELECT COUNT(*) FROM bank_transactions").fetchone()[0]
     assert pending_date == "2024-01-02"
     assert count == 2
+
+
+def test_sync_rejects_partial_failure_payload_before_writing(tmp_path) -> None:
+    database_url = f"sqlite:///{tmp_path}/t.db"
+    payload = {
+        "errors": [
+            {
+                "code": "act.failed",
+                "msg": "Account temporarily unavailable",
+                "account_id": "ACT-failed",
+            }
+        ],
+        "errlist": ["Connection refresh failed"],
+        "accounts": deepcopy(SFIN_ACCOUNT_SET["accounts"]),
+    }
+
+    def fake_dump(months, app_dir):
+        return payload
+
+    with pytest.raises(SimpleFinSyncError, match="2 partial account error"):
+        sync(database_url, dump_provider=fake_dump)
+
+    assert not (tmp_path / "t.db").exists()
 
 
 def test_resolve_direction_handles_fidelity_card_and_transfer_wording() -> None:


### PR DESCRIPTION
## Problem

Three SimpleFIN defects from the backlog. A partial SimpleFIN response (HTTP 200 with `errors`/`errlist`) was counted but never raised, so `refresh_all` reported the expenses leg ok on a run that silently dropped an account (#115). The deposit trigger could treat pending or zero-posted transactions as deployable cash (#100). `dump.ts` accepted any value for the months argument (#119, SimpleFIN item).

## Fix

- `sync_expenses_db.sync` raises `SimpleFinSyncError` with the provider's error details before any SQLite write, so the previous snapshot is preserved and the existing `refresh_all` handling marks the leg failed.
- `trigger.ts` gains one `isSettledTransaction` predicate (not pending, positive safe-integer `posted`) applied before threshold detection. `DepositDetection.pending` narrows to the literal `false`.
- `dump.ts` rejects a months argument that is not an integer in 1..120 with a clear message.

## Evidence

Each fix landed red-then-green: `test_sync_rejects_partial_failure_payload_before_writing` (DID NOT RAISE, then pass), `filters unsettled deposits before detection` (3 detections, then 1), and the months validation cases (5 pass). Bun tests 13 pass. Ruff, mypy, and the non-integration suite (1114 passed, coverage 81.55%) are clean.

`bun run typecheck` in `apps/simplefin-sync` fails on `main` today with TS2688 (`tsconfig.json` names `bun-types` while the workspace installs `@types/bun`). Unrelated to this change and left for a separate issue.

Closes #115, closes #100.

Changes made by gpt-5.6-sol (Codex, herdr worker) with review and commit by Claude Fable 5.1 in Claude Code.