### PR TITLE
fix(margin): route metrics to the unique taxable_margin account and validate the balance generation

### DIFF
--- a/src/analysis/margin_metrics.py
+++ b/src/analysis/margin_metrics.py
@@ -9,23 +9,42 @@ Fallbacks: ``--source snaptrade`` reads the SnapTrade API live, and
 
 from __future__ import annotations
 
-import argparse
 import csv
-import json
 import os
 import sqlite3
-from dataclasses import asdict, dataclass
 from datetime import date
 from glob import glob
 from pathlib import Path
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict
+
 from src.config.instance_paths import InstancePaths, load_instance_env
 
+EDUCATIONAL_DISCLAIMER = (
+    "For educational purposes only. This is not investment advice. Consult a "
+    "licensed financial professional before making financial decisions. Investing "
+    "and the use of margin involve risk, including possible loss of principal."
+)
+SUPPORTED_MARGIN_SOURCES = ("db", "snaptrade", "csv")
 
-@dataclass(frozen=True)
-class FidelityBalances:
+
+class MarginAccountRoutingError(ValueError):
+    """Raised when taxable-margin account routing is missing or ambiguous."""
+
+
+class IncompleteBalanceGenerationError(ValueError):
+    """Raised when the latest DB balance generation is incomplete."""
+
+
+class UnsupportedMarginSourceError(ValueError):
+    """Raised when runtime metrics receive an unknown balance source."""
+
+
+class FidelityBalances(BaseModel):
     """Current broker balances (from a Fidelity CSV or derived from SnapTrade)."""
+
+    model_config = ConfigDict(frozen=True)
 
     source_file: str
     total_account_value: float
@@ -37,9 +56,22 @@ class FidelityBalances:
     margin_interest_accrued_this_month: float | None
 
 
-@dataclass(frozen=True)
-class MarginMetrics:
+class MarginMetricsInput(BaseModel):
+    """Validated inputs for the margin calculator."""
+
+    model_config = ConfigDict(frozen=True)
+
+    balances: FidelityBalances
+    annual_rate: float
+    jump_alert_threshold: float
+    monthly_dividend_income: float | None = None
+    today: date | None = None
+
+
+class MarginMetrics(BaseModel):
     """Derived margin health metrics."""
+
+    model_config = ConfigDict(frozen=True)
 
     as_of_date: str
     source_file: str
@@ -57,6 +89,7 @@ class MarginMetrics:
     margin_day_change: float | None
     alert_status: str
     months_elapsed: int | None
+    disclaimer: str = EDUCATIONAL_DISCLAIMER
 
 
 def parse_money(value: str | None) -> float | None:
@@ -172,37 +205,66 @@ def _broker_balances_from_snaptrade(client: Any, account_id: str) -> FidelityBal
     )
 
 
-def read_snaptrade_balances(
+def _resolve_margin_routing(
     config_path: str | Path | None = None,
-) -> FidelityBalances:
-    """Pull live balances for the first enabled+routed SnapTrade account."""
-    from src.integrations.snaptrade.client import SnapTradeClientWrapper
-    from src.integrations.snaptrade.models import SnapTradeAccountsConfig
+) -> tuple[str, set[str], Path]:
+    """Return the unique taxable-margin account and current generation members."""
+    from src.integrations.snaptrade.models import (
+        AccountRole,
+        SnapTradeAccountsConfig,
+    )
 
-    resolved_config_path = (
+    resolved_path = (
         Path(config_path)
         if config_path is not None
         else InstancePaths.resolve().snaptrade_accounts
     )
-    config = SnapTradeAccountsConfig.from_path(resolved_config_path)
-    syncable = config.syncable
-    if not syncable:
-        msg = (
-            "No SnapTrade account is enabled+routed in "
-            f"{resolved_config_path}; cannot read margin balances"
+    config = SnapTradeAccountsConfig.from_path(resolved_path)
+    matches = [
+        account
+        for account in config.accounts
+        if account.enabled and account.role == AccountRole.TAXABLE_MARGIN
+    ]
+    if not matches:
+        raise MarginAccountRoutingError(
+            "No enabled taxable_margin account found in "
+            f"{resolved_path}; configure exactly one account with "
+            "role=taxable_margin and enabled=true"
         )
-        raise ValueError(msg)
+    if len(matches) > 1:
+        raise MarginAccountRoutingError(
+            f"Found {len(matches)} enabled taxable_margin accounts in "
+            f"{resolved_path}; exactly one is required. Disable or reroute all but one"
+        )
+    generation_account_ids = {
+        account.snaptrade_account_id for account in config.syncable
+    }
+    return matches[0].snaptrade_account_id, generation_account_ids, resolved_path
+
+
+def read_snaptrade_balances(
+    config_path: str | Path | None = None,
+) -> FidelityBalances:
+    """Pull live balances for the unique enabled taxable-margin account."""
+    from src.integrations.snaptrade.client import SnapTradeClientWrapper
+
+    margin_account_id, _generation_account_ids, _resolved_path = (
+        _resolve_margin_routing(config_path)
+    )
     client = SnapTradeClientWrapper.from_env()
-    return _broker_balances_from_snaptrade(client, syncable[0].snaptrade_account_id)
+    return _broker_balances_from_snaptrade(client, margin_account_id)
 
 
-def read_db_balances(database_url: str | None = None) -> FidelityBalances:
+def read_db_balances(
+    database_url: str | None = None,
+    config_path: str | Path | None = None,
+) -> FidelityBalances:
     """Read the latest balances snapshot the refresh wrote to the local DB.
 
-    The sync-first refresh (``src.integrations.refresh_all``) writes a current
-    SnapTrade snapshot to the ``balances`` table, so reading that row makes the
-    local DB the single source of truth. Margin debt is the derived loan
-    (SnapTrade does not expose it), so accrued interest and day-change are None.
+    The sync-first refresh (``src.integrations.refresh_all``) writes one timestamp
+    across all enabled+routed accounts. This reader requires that complete
+    generation, then selects its unique taxable-margin row. Margin debt is the
+    derived loan, so accrued interest and day-change are None.
     """
     from src.config.instance_paths import _db_path
 
@@ -213,18 +275,46 @@ def read_db_balances(database_url: str | None = None) -> FidelityBalances:
             "(uv run python -m src.integrations.refresh_all) before reading margin metrics"
         )
         raise FileNotFoundError(msg)
+    margin_account_id, generation_account_ids, resolved_config_path = (
+        _resolve_margin_routing(config_path)
+    )
     conn = sqlite3.connect(db)
     try:
         conn.row_factory = sqlite3.Row
+        latest = conn.execute(
+            "SELECT MAX(synced_at) AS synced_at FROM balances"
+        ).fetchone()
+        latest_synced_at = latest["synced_at"] if latest is not None else None
+        if latest_synced_at is None:
+            msg = "No balances rows in the local DB; run the sync-first refresh first"
+            raise ValueError(msg)
+        current_generation_rows = conn.execute(
+            "SELECT account_id FROM balances WHERE synced_at = ?",
+            (latest_synced_at,),
+        ).fetchall()
+        current_generation_account_ids = {
+            current_row["account_id"] for current_row in current_generation_rows
+        }
+        if current_generation_account_ids != generation_account_ids:
+            raise IncompleteBalanceGenerationError(
+                f"Latest balance generation at {latest_synced_at} is incomplete for "
+                f"{resolved_config_path}: expected {len(generation_account_ids)} "
+                "enabled+routed account rows but found "
+                f"{len(current_generation_account_ids)}; run the sync-first refresh "
+                "and resolve any per-account sync errors"
+            )
         row = conn.execute(
             "SELECT account_equity, buying_power, margin_debt, synced_at "
-            "FROM balances ORDER BY synced_at DESC LIMIT 1"
+            "FROM balances WHERE account_id = ? AND synced_at = ?",
+            (margin_account_id, latest_synced_at),
         ).fetchone()
     finally:
         conn.close()
     if row is None:
-        msg = "No balances rows in the local DB; run the sync-first refresh first"
-        raise ValueError(msg)
+        raise IncompleteBalanceGenerationError(
+            "The configured taxable_margin account is missing from the latest balance "
+            "generation; run the sync-first refresh and resolve any per-account sync errors"
+        )
     equity = row["account_equity"]
     if equity is None:
         msg = "Local DB balance row is missing account_equity"
@@ -254,6 +344,69 @@ def months_elapsed_since_start(today: date | None = None) -> int | None:
     return max(0, (current - start).days // 30)
 
 
+class MarginMetricsCalculator:
+    """Calculate margin-health metrics from validated inputs."""
+
+    def __init__(self, inputs: MarginMetricsInput):
+        self.inputs = inputs
+
+    def calculate_all(self) -> MarginMetrics:
+        """Return all derived margin metrics."""
+        balances = self.inputs.balances
+        margin_balance = abs(balances.net_debit)
+        monthly_interest_cost = margin_balance * self.inputs.annual_rate / 12
+        annual_interest_cost = monthly_interest_cost * 12
+        coverage_ratio = (
+            self.inputs.monthly_dividend_income / monthly_interest_cost
+            if self.inputs.monthly_dividend_income is not None
+            and monthly_interest_cost > 0
+            else None
+        )
+        portfolio_margin_ratio = (
+            balances.total_account_value / margin_balance
+            if margin_balance > 0
+            else None
+        )
+
+        if portfolio_margin_ratio is None or margin_balance == 0:
+            alert_status = "no_margin"
+        elif portfolio_margin_ratio < 2.5:
+            alert_status = "critical"
+        elif portfolio_margin_ratio < 3.0:
+            alert_status = "red"
+        elif portfolio_margin_ratio < 4.0:
+            alert_status = "yellow"
+        else:
+            alert_status = "green"
+
+        return MarginMetrics(
+            as_of_date=(self.inputs.today or date.today()).isoformat(),
+            source_file=balances.source_file,
+            portfolio_value=round(balances.total_account_value, 2),
+            margin_balance=round(margin_balance, 2),
+            margin_buying_power=balances.margin_buying_power,
+            margin_interest_accrued_this_month=(
+                balances.margin_interest_accrued_this_month
+            ),
+            annual_interest_rate=self.inputs.annual_rate,
+            monthly_interest_cost=round(monthly_interest_cost, 2),
+            annual_interest_cost=round(annual_interest_cost, 2),
+            monthly_dividend_income=self.inputs.monthly_dividend_income,
+            coverage_ratio=(
+                round(coverage_ratio, 2) if coverage_ratio is not None else None
+            ),
+            portfolio_margin_ratio=(
+                round(portfolio_margin_ratio, 2)
+                if portfolio_margin_ratio is not None
+                else None
+            ),
+            jump_alert_threshold=self.inputs.jump_alert_threshold,
+            margin_day_change=balances.net_debit_day_change,
+            alert_status=alert_status,
+            months_elapsed=months_elapsed_since_start(self.inputs.today),
+        )
+
+
 def calculate_margin_metrics(
     balances: FidelityBalances,
     *,
@@ -262,52 +415,15 @@ def calculate_margin_metrics(
     monthly_dividend_income: float | None = None,
     today: date | None = None,
 ) -> MarginMetrics:
-    """Calculate live margin metrics from balances and config."""
-    margin_balance = abs(balances.net_debit)
-    monthly_interest_cost = margin_balance * annual_rate / 12
-    annual_interest_cost = monthly_interest_cost * 12
-    coverage_ratio = (
-        monthly_dividend_income / monthly_interest_cost
-        if monthly_dividend_income is not None and monthly_interest_cost > 0
-        else None
-    )
-    portfolio_margin_ratio = (
-        balances.total_account_value / margin_balance if margin_balance > 0 else None
-    )
-
-    if portfolio_margin_ratio is None or margin_balance == 0:
-        alert_status = "no_margin"
-    elif portfolio_margin_ratio < 2.5:
-        alert_status = "critical"
-    elif portfolio_margin_ratio < 3.0:
-        alert_status = "red"
-    elif portfolio_margin_ratio < 4.0:
-        alert_status = "yellow"
-    else:
-        alert_status = "green"
-
-    return MarginMetrics(
-        as_of_date=(today or date.today()).isoformat(),
-        source_file=balances.source_file,
-        portfolio_value=round(balances.total_account_value, 2),
-        margin_balance=round(margin_balance, 2),
-        margin_buying_power=balances.margin_buying_power,
-        margin_interest_accrued_this_month=balances.margin_interest_accrued_this_month,
-        annual_interest_rate=annual_rate,
-        monthly_interest_cost=round(monthly_interest_cost, 2),
-        annual_interest_cost=round(annual_interest_cost, 2),
-        monthly_dividend_income=monthly_dividend_income,
-        coverage_ratio=round(coverage_ratio, 2) if coverage_ratio is not None else None,
-        portfolio_margin_ratio=(
-            round(portfolio_margin_ratio, 2)
-            if portfolio_margin_ratio is not None
-            else None
-        ),
+    """Calculate live margin metrics through validated models."""
+    inputs = MarginMetricsInput(
+        balances=balances,
+        annual_rate=annual_rate,
         jump_alert_threshold=jump_alert_threshold,
-        margin_day_change=balances.net_debit_day_change,
-        alert_status=alert_status,
-        months_elapsed=months_elapsed_since_start(today),
+        monthly_dividend_income=monthly_dividend_income,
+        today=today,
     )
+    return MarginMetricsCalculator(inputs).calculate_all()
 
 
 def metrics_from_runtime(
@@ -324,6 +440,11 @@ def metrics_from_runtime(
     ``source="snaptrade"`` reads the SnapTrade API live, and ``source="csv"``
     (or passing ``csv_path``) reads the legacy Fidelity balances CSV instead.
     """
+    if source not in SUPPORTED_MARGIN_SOURCES:
+        supported = ", ".join(SUPPORTED_MARGIN_SOURCES)
+        raise UnsupportedMarginSourceError(
+            f"Unsupported margin source {source!r}; expected one of: {supported}"
+        )
     load_instance_env(InstancePaths.resolve(), override=False)
     if csv_path is not None or source == "csv":
         balances = read_fidelity_balances(csv_path)
@@ -351,53 +472,12 @@ def metrics_from_runtime(
     )
 
 
-def _json_default(value: Any) -> Any:
-    if isinstance(value, Path):
-        return str(value)
-    return value
+def main(argv: list[str] | None = None) -> int:
+    """Run the compatibility CLI entrypoint."""
+    from src.analysis.margin_metrics_cli import main as cli_main
 
-
-def main() -> None:
-    """Run the margin metrics CLI."""
-    parser = argparse.ArgumentParser(description="Calculate live margin health metrics")
-    parser.add_argument(
-        "--source",
-        choices=("db", "snaptrade", "csv"),
-        default="db",
-        help=(
-            "Balance source. Defaults to the local DB snapshot (sync-first store); "
-            "'snaptrade' reads the API live; 'csv' reads a Fidelity export."
-        ),
-    )
-    parser.add_argument("--csv", help="Specific Fidelity balances CSV to read")
-    parser.add_argument(
-        "--annual-rate",
-        type=parse_rate,
-        help="Annual margin rate as decimal or percent; defaults to .env",
-    )
-    parser.add_argument(
-        "--monthly-dividend-income",
-        type=parse_money,
-        help="Current monthly dividend income; defaults to FG_DIVIDEND_MONTHLY_INCOME if set",
-    )
-    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
-    args = parser.parse_args()
-
-    metrics = metrics_from_runtime(
-        source=args.source,
-        csv_path=args.csv,
-        annual_rate=args.annual_rate,
-        monthly_dividend_income=args.monthly_dividend_income,
-    )
-    print(
-        json.dumps(
-            asdict(metrics),
-            default=_json_default,
-            indent=2 if args.pretty else None,
-            sort_keys=True,
-        )
-    )
+    return cli_main(argv)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/analysis/margin_metrics_cli.py
+++ b/src/analysis/margin_metrics_cli.py
@@ -1,0 +1,62 @@
+"""CLI interface for validated margin-health metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from src.analysis.margin_metrics import (
+    SUPPORTED_MARGIN_SOURCES,
+    metrics_from_runtime,
+    parse_money,
+    parse_rate,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Calculate and print current margin-health metrics as JSON."""
+    parser = argparse.ArgumentParser(description="Calculate live margin health metrics")
+    parser.add_argument(
+        "--source",
+        choices=SUPPORTED_MARGIN_SOURCES,
+        default="db",
+        help=(
+            "Balance source. Defaults to the local DB snapshot (sync-first store); "
+            "'snaptrade' reads the API live; 'csv' reads a Fidelity export."
+        ),
+    )
+    parser.add_argument("--csv", help="Specific Fidelity balances CSV to read")
+    parser.add_argument(
+        "--annual-rate",
+        type=parse_rate,
+        help="Annual margin rate as decimal or percent; defaults to .env",
+    )
+    parser.add_argument(
+        "--monthly-dividend-income",
+        type=parse_money,
+        help=(
+            "Current monthly dividend income; defaults to "
+            "FG_DIVIDEND_MONTHLY_INCOME if set"
+        ),
+    )
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    args = parser.parse_args(argv)
+
+    metrics = metrics_from_runtime(
+        source=args.source,
+        csv_path=args.csv,
+        annual_rate=args.annual_rate,
+        monthly_dividend_income=args.monthly_dividend_income,
+    )
+    print(
+        json.dumps(
+            metrics.model_dump(mode="json"),
+            indent=2 if args.pretty else None,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_margin_metrics.py
+++ b/tests/python/test_margin_metrics.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
+import sys
 from datetime import date
+from pathlib import Path
 
 import pytest
 
 from src.analysis import margin_metrics as mm
 from src.analysis.margin_metrics import (
     FidelityBalances,
+    IncompleteBalanceGenerationError,
+    MarginAccountRoutingError,
+    UnsupportedMarginSourceError,
     _broker_balances_from_snaptrade,
     calculate_margin_metrics,
     metrics_from_runtime,
@@ -26,6 +32,42 @@ def write_balances(path):
         "Net debit,-10000.00,-500.00\n"
         "Margin interest accrued this month,12.34,\n"
     )
+
+
+def write_account_config(path: Path, accounts: list[tuple[str, str, bool]]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-01-01T00:00:00+00:00",
+                "accounts": [
+                    {
+                        "snaptrade_account_id": account_id,
+                        "role": role,
+                        "enabled": enabled,
+                    }
+                    for account_id, role, enabled in accounts
+                ],
+            }
+        )
+    )
+
+
+def write_balances_db(
+    path: Path, rows: list[tuple[str, float, float, float, str]]
+) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE balances (account_id TEXT PRIMARY KEY, currency TEXT, "
+            "settled_cash REAL, buying_power REAL, account_equity REAL, "
+            "gross_market_value REAL, margin_debt REAL, synced_at TEXT NOT NULL)"
+        )
+        conn.executemany(
+            "INSERT INTO balances VALUES (?, 'USD', 0.0, ?, ?, 0.0, ?, ?)", rows
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def test_parse_money_supports_currency_commas_percent_and_k():
@@ -174,8 +216,32 @@ def test_metrics_from_runtime_snaptrade_source_reads_api(monkeypatch):
     assert metrics.margin_balance == 83820.02
 
 
+def test_metrics_from_runtime_rejects_unsupported_source(monkeypatch):
+    sentinel = FidelityBalances(
+        source_file="db:synthetic.db",
+        total_account_value=100000.0,
+        total_account_day_change=None,
+        margin_buying_power=1000.0,
+        margin_buying_power_day_change=None,
+        net_debit=-10000.0,
+        net_debit_day_change=None,
+        margin_interest_accrued_this_month=None,
+    )
+    monkeypatch.setattr(mm, "read_db_balances", lambda: sentinel)
+    monkeypatch.setenv("FG_MARGIN_JUMP_ALERT_THRESHOLD", "$5,000")
+
+    with pytest.raises(UnsupportedMarginSourceError) as exc_info:
+        metrics_from_runtime(source="unsupported", annual_rate=0.12)
+
+    assert "db, snaptrade, csv" in str(exc_info.value)
+
+
 def test_read_db_balances_reads_latest_snapshot(tmp_path, monkeypatch):
     """read_db_balances returns the newest balances row as Fidelity-shaped facts."""
+    write_account_config(
+        tmp_path / "snaptrade-accounts.yaml",
+        [("acct-1", "taxable_margin", True)],
+    )
     db_path = tmp_path / "family_office.db"
     conn = sqlite3.connect(db_path)
     try:
@@ -191,6 +257,7 @@ def test_read_db_balances_reads_latest_snapshot(tmp_path, monkeypatch):
         conn.commit()
     finally:
         conn.close()
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
 
     balances = mm.read_db_balances()
@@ -199,6 +266,183 @@ def test_read_db_balances_reads_latest_snapshot(tmp_path, monkeypatch):
     assert balances.total_account_value == 150000.00
     assert balances.net_debit == pytest.approx(-50000.00)
     assert balances.margin_interest_accrued_this_month is None
+
+
+def test_read_db_balances_routes_to_unique_enabled_taxable_margin_account(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "snaptrade-accounts.yaml"
+    write_account_config(
+        config_path,
+        [
+            ("synthetic-retirement", "retirement", True),
+            ("synthetic-margin", "taxable_margin", True),
+            ("synthetic-margin-disabled", "taxable_margin", False),
+        ],
+    )
+    db_path = tmp_path / "family_office.db"
+    write_balances_db(
+        db_path,
+        [
+            (
+                "synthetic-retirement",
+                1000.0,
+                900000.0,
+                0.0,
+                "2026-01-01T00:00:00+00:00",
+            ),
+            (
+                "synthetic-margin",
+                5000.0,
+                150000.0,
+                50000.0,
+                "2026-01-01T00:00:00+00:00",
+            ),
+        ],
+    )
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    balances = mm.read_db_balances()
+
+    assert balances.total_account_value == 150000.0
+    assert balances.net_debit == -50000.0
+
+
+def test_read_db_balances_rejects_missing_taxable_margin_account(tmp_path, monkeypatch):
+    write_account_config(
+        tmp_path / "snaptrade-accounts.yaml",
+        [
+            ("synthetic-retirement", "retirement", True),
+            ("synthetic-margin-disabled", "taxable_margin", False),
+        ],
+    )
+    db_path = tmp_path / "family_office.db"
+    write_balances_db(
+        db_path,
+        [
+            (
+                "synthetic-retirement",
+                1000.0,
+                900000.0,
+                0.0,
+                "2026-01-01T00:00:00+00:00",
+            ),
+        ],
+    )
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    with pytest.raises(MarginAccountRoutingError) as exc_info:
+        mm.read_db_balances()
+
+    assert "exactly one" in str(exc_info.value)
+
+
+def test_read_db_balances_rejects_ambiguous_taxable_margin_accounts(
+    tmp_path, monkeypatch
+):
+    write_account_config(
+        tmp_path / "snaptrade-accounts.yaml",
+        [
+            ("synthetic-margin-a", "taxable_margin", True),
+            ("synthetic-margin-b", "taxable_margin", True),
+        ],
+    )
+    db_path = tmp_path / "family_office.db"
+    write_balances_db(
+        db_path,
+        [
+            (
+                "synthetic-margin-a",
+                1000.0,
+                100000.0,
+                10000.0,
+                "2026-01-01T00:00:00+00:00",
+            ),
+            (
+                "synthetic-margin-b",
+                2000.0,
+                200000.0,
+                20000.0,
+                "2026-01-01T00:00:00+00:00",
+            ),
+        ],
+    )
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    with pytest.raises(MarginAccountRoutingError) as exc_info:
+        mm.read_db_balances()
+
+    assert "Found 2" in str(exc_info.value)
+
+
+def test_read_db_balances_rejects_incomplete_latest_generation(tmp_path, monkeypatch):
+    write_account_config(
+        tmp_path / "snaptrade-accounts.yaml",
+        [
+            ("synthetic-margin", "taxable_margin", True),
+            ("synthetic-retirement", "retirement", True),
+        ],
+    )
+    db_path = tmp_path / "family_office.db"
+    write_balances_db(
+        db_path,
+        [
+            (
+                "synthetic-margin",
+                1000.0,
+                100000.0,
+                10000.0,
+                "2026-01-01T00:00:00+00:00",
+            ),
+            (
+                "synthetic-retirement",
+                2000.0,
+                200000.0,
+                0.0,
+                "2026-01-02T00:00:00+00:00",
+            ),
+        ],
+    )
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    with pytest.raises(IncompleteBalanceGenerationError) as exc_info:
+        mm.read_db_balances()
+
+    assert "run the sync-first refresh" in str(exc_info.value)
+
+
+def test_margin_cli_json_includes_educational_disclaimer(tmp_path, monkeypatch, capsys):
+    csv_path = tmp_path / "Balances_for_Account_SYNTHETIC.csv"
+    write_balances(csv_path)
+    monkeypatch.setenv("FG_MARGIN_JUMP_ALERT_THRESHOLD", "$5,000")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "margin_metrics",
+            "--source",
+            "csv",
+            "--csv",
+            str(csv_path),
+            "--annual-rate",
+            "0.12",
+            "--monthly-dividend-income",
+            "250",
+            "--pretty",
+        ],
+    )
+
+    mm.main()
+
+    output = json.loads(capsys.readouterr().out)
+    assert "educational purposes only" in output["disclaimer"].lower()
+    assert "not investment advice" in output["disclaimer"].lower()
+    assert "licensed financial professional" in output["disclaimer"].lower()
+    assert "loss of principal" in output["disclaimer"].lower()
 
 
 def test_broker_balances_from_snaptrade_derives_net_debit():


### PR DESCRIPTION
## Problem

`margin_metrics` read the newest `balances` row with no account filter, and the SnapTrade path took the first syncable account. Both silently read a retirement or watch-only row as soon as a second account is enabled (#118, #103). The module also accepted unknown `--source` values, trusted a possibly partial balance generation, skipped the mandated disclaimer, and did not follow the repo's three-layer shape (#119, margin items).

## Fix

- One routing helper requires exactly one enabled `taxable_margin` account and raises `MarginAccountRoutingError` with a configuration hint on zero or many matches.
- The DB reader verifies the latest `synced_at` generation contains every enabled+routed account before selecting the routed account's row, raising `IncompleteBalanceGenerationError` otherwise.
- Unsupported sources raise `UnsupportedMarginSourceError` instead of falling through.
- Models are Pydantic, the math lives in `MarginMetricsCalculator`, and argparse moved to `margin_metrics_cli.py`. `python -m src.analysis.margin_metrics` still works. Output JSON gains a `disclaimer` field; no strict consumer of that JSON exists in the repo.

## Evidence

Six new tests cover unique, missing, ambiguous routing, incomplete generation, unsupported source, and the disclaimer. Red evidence for the routing defect: `assert 900000.0 == 150000.0` (the wrong account's equity). Ruff, mypy, and the non-integration suite (1119 passed, coverage 81.90%) are clean.

Closes #103, closes #118.

Changes made by gpt-5.6-sol (Codex, herdr worker) with review and commit by Claude Fable 5.1 in Claude Code.