### PR TITLE
fix(cli): restore broken CLI help paths, harden onboarding state writes, add plugin-mode instance init

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - anthropic>=0.107.1
           - pydantic>=2.10.6
           - types-requests
           - types-PyYAML

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,7 +53,9 @@ uv run python -m src.integrations.refresh_all --help
 | Command | Purpose |
 | --- | --- |
 | `src/utils/data_validator_cli.py` | Check data quality. |
+| `uv run python -m src.utils.input_validation_cli` | Validate financial time-series inputs. |
 | `src/utils/market_data.py` | Retrieve market data. |
+| `src/utils/momentum_cli.py` | Calculate momentum indicators. |
 | `src/utils/moving_averages_cli.py` | Calculate moving averages and crossover signals. |
 | `src/utils/screener_cli.py` | Run the market screener. |
 | `src/utils/volatility_cli.py` | Calculate volatility indicators. |
@@ -78,16 +80,6 @@ fresh setup.
 | `uv run python -m src.integrations.snaptrade.sync_db` | Refresh SnapTrade positions and balances into local SQLite. |
 | `uv run python -m src.integrations.snaptrade.sync_transactions_db` | Refresh SnapTrade activities into local SQLite. |
 | `uv run python -m src.integrations.simplefin.sync_expenses_db` | Refresh SimpleFIN transactions into local SQLite. |
-
-## Known unavailable commands
-
-These checked-in entry points are intentionally excluded from the supported
-inventory until their tracked defects are resolved:
-
-- `src/utils/momentum_cli.py --help` fails because an unescaped percent sign
-  breaks argparse help rendering ([#108](https://github.com/AojdevStudio/Finance-Guru/issues/108)).
-- `src.utils.input_validation_cli` fails before argument parsing because it
-  imports an obsolete `MarketDataFetcher` symbol ([#120](https://github.com/AojdevStudio/Finance-Guru/issues/120)).
 
 ## Output and safety
 

--- a/src/cli/instance_init.py
+++ b/src/cli/instance_init.py
@@ -2,6 +2,10 @@
 
 The scaffold commit runs before uv sync so it cannot include a partial virtual
 environment, and the later migration commit owns ``uv.lock``.
+
+An installed Finance Guru plugin is the source of truth for agents, skills, and
+hooks, so plugin-mode instances omit ``.claude`` and ``.agents`` symlinks.
+Checkout-mode instances link both paths to the checkout's ``.claude`` tree.
 """
 
 from __future__ import annotations
@@ -191,15 +195,25 @@ Example: `uv run python -m src.integrations.refresh_all --show`
 """
 
 
-def _instance_agent_instructions(repo: Path) -> str:
+def _instance_agent_instructions(repo: Path, *, plugin_mode: bool) -> str:
+    if plugin_mode:
+        discovery_instructions = """The installed Finance Guru plugin is the source of truth for agents, skills, and hooks.
+This instance intentionally omits `.claude` and `.agents` symlinks.
+"""
+    else:
+        discovery_instructions = f"""This instance's `.agents` symlink points to
+`{repo / ".claude"}`, so Codex discovers the canonical skills under
+`.agents/skills/`. Read a skill's complete `SKILL.md` before using it. Do not
+copy or fork skill content into this instance.
+"""
+
     return f"""# Finance Guru instance
 
 Before doing Finance Guru work, read `{repo / "AGENTS.md"}` in full.
 
-The engine lives at `{repo}`. This instance's `.agents` symlink points to
-`{repo / ".claude"}`, so Codex discovers the canonical skills under
-`.agents/skills/`. Read a skill's complete `SKILL.md` before using it. Do not
-copy or fork skill content into this instance.
+The engine lives at `{repo}`.
+
+{discovery_instructions}
 
 Run engine commands from this instance as `uv run python -m src.<tool>` so all
 private paths resolve from the current directory.
@@ -228,7 +242,9 @@ def _sync_environment(path: Path) -> StepResult:
     return "exists" if existed else "created"
 
 
-def _build_plan(paths: InstancePaths, repo: Path) -> list[PlanStep]:
+def _build_plan(
+    paths: InstancePaths, repo: Path, *, plugin_mode: bool
+) -> list[PlanStep]:
     directory_paths = (
         paths.imports,
         paths.analysis,
@@ -252,15 +268,26 @@ def _build_plan(paths: InstancePaths, repo: Path) -> list[PlanStep]:
             ),
             PlanStep(paths.env_file, _write_text(env_content)),
             PlanStep(paths.profile, _write_text(USER_PROFILE)),
-            PlanStep(paths.root / ".agents", _create_symlink(repo / ".claude")),
-            PlanStep(paths.root / ".claude", _create_symlink(repo / ".claude")),
+        )
+    )
+    if not plugin_mode:
+        plan.extend(
+            (
+                PlanStep(paths.root / ".agents", _create_symlink(repo / ".claude")),
+                PlanStep(paths.root / ".claude", _create_symlink(repo / ".claude")),
+            )
+        )
+    plan.extend(
+        (
             PlanStep(
                 paths.root / "CLAUDE.md",
                 _write_text(_instance_instructions(repo)),
             ),
             PlanStep(
                 paths.root / "AGENTS.md",
-                _write_text(_instance_agent_instructions(repo)),
+                _write_text(
+                    _instance_agent_instructions(repo, plugin_mode=plugin_mode)
+                ),
             ),
             PlanStep(paths.root / ".git", _initialize_git),
             PlanStep(paths.root / ".venv", _sync_environment),
@@ -278,7 +305,22 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         required=True,
         help="Finance Guru engine checkout",
     )
+    parser.add_argument(
+        "--plugin",
+        action="store_true",
+        help="Use the installed plugin as the agent, skill, and hook source",
+    )
     return parser.parse_args(argv)
+
+
+def _uses_installed_plugin(repo: Path, *, explicit: bool) -> bool:
+    if explicit:
+        return True
+
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root is None:
+        return False
+    return Path(plugin_root).expanduser().resolve() == repo
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -286,11 +328,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     paths = InstancePaths(root=args.root.expanduser().resolve())
     repo = args.repo.expanduser().resolve()
+    plugin_mode = _uses_installed_plugin(repo, explicit=args.plugin)
 
     if (paths.root / ".git").exists():
         _reject_git_remotes(paths.root)
 
-    for step in _build_plan(paths, repo):
+    for step in _build_plan(paths, repo, plugin_mode=plugin_mode):
         result = step.action(step.target)
         print(f"{result} {step.target}")
 

--- a/src/utils/input_validation_cli.py
+++ b/src/utils/input_validation_cli.py
@@ -39,13 +39,14 @@ import json
 import sys
 from datetime import date, timedelta
 
+import yfinance as yf
+
 from src.models.validation_inputs import (
     OutlierMethod,
     PriceSeriesInput,
     ValidationConfig,
 )
 from src.utils.input_validation import InputValidator
-from src.utils.market_data import MarketDataFetcher
 
 
 def print_validation_summary(result, output_format: str = "text") -> None:
@@ -175,18 +176,14 @@ def validate_ticker(
     """
     print(f"Fetching {days} days of data for {ticker}...", file=sys.stderr)
 
-    # Fetch market data
-    fetcher = MarketDataFetcher()
-
     try:
         end_date = date.today()
         start_date = end_date - timedelta(days=days)
 
         # Get historical data
-        data = fetcher.get_historical_data(
-            ticker=ticker,
-            start_date=start_date.strftime("%Y-%m-%d"),
-            end_date=end_date.strftime("%Y-%m-%d"),
+        data = yf.Ticker(ticker).history(
+            start=start_date.strftime("%Y-%m-%d"),
+            end=end_date.strftime("%Y-%m-%d"),
         )
 
         if data is None or len(data) < 10:

--- a/src/utils/momentum_cli.py
+++ b/src/utils/momentum_cli.py
@@ -408,18 +408,18 @@ Examples:
     )
 
     parser.add_argument(
-        "--stoch-k", type=int, default=14, help="Stochastic %K period (default: 14)"
+        "--stoch-k", type=int, default=14, help="Stochastic %%K period (default: 14)"
     )
 
     parser.add_argument(
-        "--stoch-d", type=int, default=3, help="Stochastic %D period (default: 3)"
+        "--stoch-d", type=int, default=3, help="Stochastic %%D period (default: 3)"
     )
 
     parser.add_argument(
         "--williams-period",
         type=int,
         default=14,
-        help="Williams %R period (default: 14)",
+        help="Williams %%R period (default: 14)",
     )
 
     parser.add_argument(

--- a/src/utils/progress_persistence.py
+++ b/src/utils/progress_persistence.py
@@ -6,6 +6,8 @@ allowing users to complete the Finance Guru setup in multiple sessions.
 """
 
 import json
+import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
@@ -95,14 +97,28 @@ def save_state(state: OnboardingState) -> None:
         Exception: If save operation fails
     """
     state_path = get_state_path()
+    temp_path: Path | None = None
 
     try:
         state.last_updated = datetime.now().isoformat()
         content = state.model_dump_json(indent=2)
-        state_path.write_text(content, encoding="utf-8")
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=state_path.parent,
+            prefix=f".{state_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_file.write(content)
+            temp_path = Path(temp_file.name)
+        os.replace(temp_path, state_path)
     except Exception as error:
         print(f"Failed to save onboarding state: {error}")
         raise
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
 
 
 def create_new_state() -> OnboardingState:
@@ -188,12 +204,11 @@ def clear_state() -> None:
     """
     state_path = get_state_path()
 
-    if state_path.exists():
-        try:
-            state_path.unlink()
-        except Exception as error:
-            print(f"Failed to delete onboarding state: {error}")
-            raise
+    try:
+        state_path.unlink(missing_ok=True)
+    except Exception as error:
+        print(f"Failed to delete onboarding state: {error}")
+        raise
 
 
 def get_next_section(state: OnboardingState) -> SectionName | None:

--- a/tests/python/test_cli_help.py
+++ b/tests/python/test_cli_help.py
@@ -1,0 +1,38 @@
+"""Regression tests for supported CLI help entry points."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_option"),
+    (
+        ([sys.executable, "src/utils/momentum_cli.py", "--help"], "--stoch-k"),
+        (
+            [sys.executable, "-m", "src.utils.input_validation_cli", "--help"],
+            "--outlier-method",
+        ),
+    ),
+    ids=("momentum", "input-validation"),
+)
+def test_cli_help_renders_without_network(
+    command: list[str], expected_option: str
+) -> None:
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "usage:" in result.stdout
+    assert expected_option in result.stdout

--- a/tests/python/test_instance_init.py
+++ b/tests/python/test_instance_init.py
@@ -42,9 +42,15 @@ def _run_init(
     repo: Path,
     *,
     configure_git_identity: bool = True,
+    plugin: bool = False,
+    plugin_root: Path | None = None,
     sync_roots: list[Path] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
+    if plugin_root is None:
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+    else:
+        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
     if configure_git_identity:
         env.update(GIT_ENV)
     else:
@@ -57,6 +63,8 @@ def _run_init(
         env["GIT_CONFIG_VALUE_0"] = "true"
 
     args = [str(root), "--repo", str(repo)]
+    if plugin:
+        args.append("--plugin")
     stdout = io.StringIO()
     stderr = io.StringIO()
     with (
@@ -208,6 +216,32 @@ def test_fresh_root_creates_complete_instance(tmp_path: Path) -> None:
     assert _git(root, "rev-list", "--count", "HEAD") == "1"
     assert _git(root, "log", "-1", "--format=%s") == "scaffold instance"
     assert _git(root, "remote") == ""
+
+
+def test_plugin_flag_omits_harness_symlinks(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+
+    result = _run_init(root, repo, plugin=True)
+
+    assert result.returncode == 0, result.stderr
+    assert not (root / ".claude").exists()
+    assert not (root / ".agents").exists()
+    agent_instructions = (root / "AGENTS.md").read_text(encoding="utf-8")
+    assert "plugin is the source of truth for agents, skills, and hooks" in (
+        agent_instructions
+    )
+
+
+def test_matching_plugin_root_omits_harness_symlinks(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    root = tmp_path / "instance"
+
+    result = _run_init(root, repo, plugin_root=repo)
+
+    assert result.returncode == 0, result.stderr
+    assert not (root / ".claude").exists()
+    assert not (root / ".agents").exists()
 
 
 @pytest.mark.parametrize("empty_value", ['""', "''", "   "])

--- a/tests/python/test_progress_persistence.py
+++ b/tests/python/test_progress_persistence.py
@@ -18,6 +18,7 @@ Test Categories:
 
 import json
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import pytest
 
@@ -111,6 +112,22 @@ class TestStateManagement:
     def test_clear_nonexistent_state(self):
         """Clearing nonexistent state should not error."""
         clear_state()  # Should not raise
+
+    def test_clear_state_tolerates_concurrent_removal(self, monkeypatch):
+        """A concurrent delete should leave the state cleared without error."""
+        state_path = get_state_path()
+        state_path.write_text("{}", encoding="utf-8")
+        original_unlink = Path.unlink
+
+        def remove_before_unlink(path: Path, *, missing_ok: bool = False) -> None:
+            original_unlink(path, missing_ok=True)
+            original_unlink(path, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", remove_before_unlink)
+
+        clear_state()
+
+        assert not state_path.exists()
 
     def test_save_updates_timestamp(self):
         """Saving should update the last_updated timestamp."""
@@ -436,3 +453,27 @@ class TestEdgeCases:
         loaded = load_state()
         assert loaded is not None
         assert loaded.current_section == "investments"
+
+    def test_failed_atomic_replace_preserves_previous_state(self, monkeypatch):
+        """An interrupted replacement should leave the prior state readable."""
+        original_state = create_new_state()
+        original_state.current_section = "liquid_assets"
+        save_state(original_state)
+        state_path = get_state_path()
+        previous_content = state_path.read_text(encoding="utf-8")
+
+        replacement_state = create_new_state()
+        replacement_state.current_section = "investments"
+
+        def fail_replace(source: Path, destination: Path) -> None:
+            raise OSError(f"interrupted replacement of {source} with {destination}")
+
+        monkeypatch.setattr("os.replace", fail_replace)
+
+        with pytest.raises(OSError, match="interrupted replacement"):
+            save_state(replacement_state)
+
+        assert state_path.read_text(encoding="utf-8") == previous_content
+        loaded = load_state()
+        assert loaded is not None
+        assert loaded.current_section == "liquid_assets"


### PR DESCRIPTION
## Problem

Five small backlog items in the CLI and onboarding surface. `momentum_cli --help` crashed on an unescaped percent sign (#108). `input_validation_cli` imported the removed `MarketDataFetcher` and could not start (#120). Onboarding state writes were non-atomic and `clear_state` was check-then-unlink (#139). `instance_init` always created `.claude` and `.agents` symlinks, so every agent and skill appeared twice when the finance-guru plugin was installed (#150). The pre-commit mypy hook lacked `anthropic` and failed on `buy_ticket_agent` (#111).

## Fix

- Escape the percent literals in the momentum help strings.
- Read history through `yfinance` directly in the validation CLI, the same boundary the rest of `src` uses.
- Write onboarding state to a same-directory temp file and `os.replace` it; `clear_state` uses `unlink(missing_ok=True)`.
- `instance_init --plugin` (or a `CLAUDE_PLUGIN_ROOT` that resolves to the repo) skips the two symlinks and writes plugin-mode agent instructions. The module docstring states the plugin is the source of truth for hooks in that mode.
- Add `anthropic>=0.107.1` to the mirrors-mypy hook.
- The CLI reference drops its known-unavailable section and lists both commands again.

## Evidence

Six new tests, each seen red first (format character error, ImportError, DID NOT RAISE OSError, FileNotFoundError, SystemExit 2, symlink assertion). Pre-commit mypy passes. Ruff, mypy, and the non-integration suite (1119 passed, coverage 81.58%) are clean. All three help commands exit 0.

Closes #108, closes #120, closes #139, closes #150, closes #111.

Changes made by gpt-5.6-sol (Codex, herdr worker) with review and commit by Claude Fable 5.1 in Claude Code.