### PR TITLE
fix(snaptrade): key activities on provider identity, canonicalize dates, and fail closed on incomplete balances

### DIFF
--- a/src/integrations/snaptrade/cli.py
+++ b/src/integrations/snaptrade/cli.py
@@ -34,6 +34,7 @@ import yaml
 
 from src.config.instance_paths import InstancePaths
 from src.integrations.snaptrade.client import (
+    BalanceCurrencyMismatchError,
     SnapTradeAPIError,
     SnapTradeClientWrapper,
     derive_margin_debt,
@@ -219,10 +220,27 @@ def _account_positions(
 
 
 def _account_balances(
-    client: SnapTradeClientWrapper, account_id: str
+    client: SnapTradeClientWrapper, account_id: str, currency: str = "USD"
 ) -> dict[str, Any]:
     raw = client.get_balances(account_id)
-    first = raw[0] if raw else {}
+    requested_currency = currency.strip().upper()
+    selected = next(
+        (
+            balance
+            for balance in raw
+            if str(balance.get("currency") or "").strip().upper() == requested_currency
+        ),
+        None,
+    )
+    if selected is None:
+        available = sorted(
+            {
+                str(balance.get("currency")).strip().upper()
+                for balance in raw
+                if balance.get("currency")
+            }
+        )
+        raise BalanceCurrencyMismatchError(requested_currency, available)
     equity = client.get_account_equity(account_id)
     margin_debt, gross_mv = derive_margin_debt(
         client.get_positions(account_id),
@@ -230,9 +248,9 @@ def _account_balances(
         equity,
     )
     return {
-        "currency": first.get("currency"),
-        "settled_cash": first.get("cash"),  # -> SPAXX row
-        "buying_power": first.get("buying_power"),
+        "currency": requested_currency,
+        "settled_cash": selected.get("cash"),  # -> SPAXX row
+        "buying_power": selected.get("buying_power"),
         "account_equity": equity,
         "gross_market_value": gross_mv,
         "margin_debt": margin_debt,  # derived; SnapTrade omits it directly

--- a/src/integrations/snaptrade/client.py
+++ b/src/integrations/snaptrade/client.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from collections.abc import Callable, Mapping
+from datetime import UTC, date, datetime
 from typing import Any, TypeVar, cast
 
-from src.integrations.snaptrade.models import SnapTradeAccount, SnapTradeCredentials
+from src.integrations.snaptrade.models import (
+    SnapTradeAccount,
+    SnapTradeActivity,
+    SnapTradeCredentials,
+)
 
 T = TypeVar("T")
 
@@ -18,6 +25,42 @@ class SnapTradeAPIError(RuntimeError):
         """Create a sanitized API error."""
         super().__init__(message)
         self.status_code = status_code
+
+
+class SnapTradeDataError(SnapTradeAPIError):
+    """Invalid or incomplete data returned by SnapTrade."""
+
+
+class BalanceCurrencyMismatchError(SnapTradeDataError):
+    """No balance row matches the explicitly requested currency."""
+
+    def __init__(self, requested: str, available: list[str]) -> None:
+        currencies = ", ".join(available) if available else "none"
+        super().__init__(
+            f"SnapTrade has no {requested} balance row; available currencies: "
+            f"{currencies}"
+        )
+
+
+class MissingAccountEquityError(SnapTradeDataError):
+    """Margin debt cannot be derived without net account equity."""
+
+    def __init__(self) -> None:
+        super().__init__("SnapTrade account equity is missing")
+
+
+class MissingPositionMarkError(SnapTradeDataError):
+    """Gross market value cannot be derived without a held position's mark."""
+
+    def __init__(self, symbol: str) -> None:
+        super().__init__(f"SnapTrade position mark is missing for {symbol}")
+
+
+class MissingPositionQuantityError(SnapTradeDataError):
+    """Gross market value cannot be derived without a position quantity."""
+
+    def __init__(self, symbol: str) -> None:
+        super().__init__(f"SnapTrade position quantity is missing for {symbol}")
 
 
 class SnapTradeClientWrapper:
@@ -385,10 +428,12 @@ def _summarize_activity(raw_activity: Any) -> dict[str, Any]:
     """Normalize one SnapTrade activity to a stable dict the consumers ingest."""
     raw = _to_plain(raw_activity)
     if not isinstance(raw, Mapping):
-        return {}
-    return {
+        raise SnapTradeDataError("SnapTrade activity payload was not an object")
+    activity_fields = {
         "type": _first_present(raw, "type"),
-        "date": _first_present(raw, "trade_date", "settlement_date"),
+        "date": canonical_activity_date(
+            _first_present(raw, "trade_date", "settlement_date")
+        ),
         "symbol": _activity_symbol(raw),
         "amount": _to_float(_first_present(raw, "amount")),
         "quantity": _to_float(_first_present(raw, "units", "quantity")),
@@ -396,6 +441,60 @@ def _summarize_activity(raw_activity: Any) -> dict[str, Any]:
         "description": _first_present(raw, "description"),
         "account": _activity_account(raw),
     }
+    activity = SnapTradeActivity(
+        id=_activity_id(raw, activity_fields),
+        **activity_fields,
+    )
+    return activity.model_dump(mode="json")
+
+
+def canonical_activity_date(value: Any) -> date:
+    """Parse a calendar date or timezone-aware ISO 8601 datetime as a UTC date."""
+    if isinstance(value, datetime):
+        parsed_datetime = value
+    elif isinstance(value, date):
+        return value
+    elif isinstance(value, str):
+        candidate = value.strip()
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", candidate):
+            try:
+                return date.fromisoformat(candidate)
+            except ValueError as exc:
+                raise SnapTradeDataError(
+                    f"SnapTrade activity date is not ISO 8601: {value!r}"
+                ) from exc
+        if not re.match(r"^\d{4}-\d{2}-\d{2}T", candidate):
+            raise SnapTradeDataError(
+                f"SnapTrade activity date is not ISO 8601: {value!r}"
+            )
+        try:
+            parsed_datetime = datetime.fromisoformat(
+                candidate[:-1] + "+00:00" if candidate.endswith("Z") else candidate
+            )
+        except ValueError as exc:
+            raise SnapTradeDataError(
+                f"SnapTrade activity date is not ISO 8601: {value!r}"
+            ) from exc
+    else:
+        raise SnapTradeDataError("SnapTrade activity date is missing")
+    if parsed_datetime.tzinfo is None or parsed_datetime.utcoffset() is None:
+        raise SnapTradeDataError(
+            "SnapTrade activity datetime must include a timezone offset"
+        )
+    return parsed_datetime.astimezone(UTC).date()
+
+
+def _activity_id(raw: Mapping[str, Any], fields: Mapping[str, Any]) -> str:
+    provider_id = _first_present(raw, "id", "activity_id", "activityId")
+    if provider_id is not None and str(provider_id).strip():
+        return str(provider_id).strip()
+    payload = json.dumps(
+        fields,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return f"fallback:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
 
 
 def _activity_symbol(raw: Mapping[str, Any]) -> str | None:
@@ -477,24 +576,35 @@ def derive_margin_debt(
     stocks: list[dict[str, Any]],
     options: list[dict[str, Any]],
     equity: float | None,
-) -> tuple[float | None, float]:
+) -> tuple[float, float]:
     """Derive margin debt and gross market value from holdings and net equity.
 
     SnapTrade does not expose the margin loan directly. Gross long market value
     (settled cash is carried in the SPAXX position, so it is already included)
     minus net account equity recovers it (validated within ~0.1% of the broker's
     reported net debit). Options use the x100 contract multiplier. margin_debt is
-    a loan, so it is clamped to >= 0 (a net-cash account owes nothing). Returns
-    (margin_debt, gross_market_value); margin_debt is None if equity is unknown.
+    a loan, so it is clamped to >= 0 (a net-cash account owes nothing). Missing
+    equity, quantities, or marks fail closed because they make the result partial.
     """
-    stock_mv = sum((p.get("price") or 0) * (p.get("quantity") or 0) for p in stocks)
-    option_mv = sum(
-        (o.get("price") or 0) * (o.get("quantity") or 0) * 100 for o in options
-    )
-    gross_mv = round(stock_mv + option_mv, 2)
     if equity is None:
-        return None, gross_mv
+        raise MissingAccountEquityError
+    stock_mv = sum(_position_market_value(position, 1) for position in stocks)
+    option_mv = sum(_position_market_value(position, 100) for position in options)
+    gross_mv = round(stock_mv + option_mv, 2)
     return max(round(gross_mv - equity, 2), 0.0), gross_mv
+
+
+def _position_market_value(position: Mapping[str, Any], multiplier: int) -> float:
+    symbol = str(position.get("symbol") or "unknown position")
+    quantity = position.get("quantity")
+    if quantity is None:
+        raise MissingPositionQuantityError(symbol)
+    if quantity == 0:
+        return 0.0
+    price = position.get("price")
+    if price is None:
+        raise MissingPositionMarkError(symbol)
+    return float(price) * float(quantity) * multiplier
 
 
 def _position_symbol(raw_position: Any) -> str | None:

--- a/src/integrations/snaptrade/models.py
+++ b/src/integrations/snaptrade/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Self
@@ -89,6 +89,35 @@ class SnapTradeAccount(BaseModel):
     number_masked: str | None = None
     balance_total: float | None = None
     raw: dict[str, Any] = Field(default_factory=dict, exclude=True)
+
+
+class SnapTradeActivity(BaseModel):
+    """Canonical activity shape shared by CLI and SQLite consumers."""
+
+    id: str = Field(min_length=1)
+    date: date
+    type: str | None = None
+    symbol: str | None = None
+    amount: float | None = None
+    quantity: float | None = None
+    currency: str | None = None
+    description: str | None = None
+    account: str | None = None
+
+
+class UnpricedPositionLot(BaseModel):
+    """A position lot excluded from average-cost weighting."""
+
+    symbol: str
+    instrument: str
+    quantity: float | None = None
+
+
+class NettedPositions(BaseModel):
+    """Netted positions plus incomplete lots the caller must surface."""
+
+    positions: list[dict[str, Any]]
+    unpriced_lots: list[UnpricedPositionLot]
 
 
 class AccountRole(StrEnum):

--- a/src/integrations/snaptrade/sync_db.py
+++ b/src/integrations/snaptrade/sync_db.py
@@ -26,7 +26,11 @@ from typing import Any
 from src.config.instance_paths import InstancePaths, _db_path, load_instance_env
 from src.integrations.snaptrade.cli import _account_balances, _account_positions
 from src.integrations.snaptrade.client import SnapTradeAPIError, SnapTradeClientWrapper
-from src.integrations.snaptrade.models import SnapTradeAccountsConfig
+from src.integrations.snaptrade.models import (
+    NettedPositions,
+    SnapTradeAccountsConfig,
+    UnpricedPositionLot,
+)
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS positions (
@@ -52,7 +56,7 @@ CREATE TABLE IF NOT EXISTS balances (
 """
 
 
-def _net_positions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _net_positions(rows: list[dict[str, Any]]) -> NettedPositions:
     """Net multiple lots of the same (symbol, instrument) into one row.
 
     SnapTrade can return a symbol as several lots (observed: SPMO twice). The
@@ -64,20 +68,27 @@ def _net_positions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             continue
         groups[(p["symbol"], p.get("instrument", "equity"))].append(p)
     netted: list[dict[str, Any]] = []
+    unpriced_lots: list[UnpricedPositionLot] = []
     for (symbol, instrument), lots in groups.items():
         qty = sum((lot.get("quantity") or 0) for lot in lots)
         cost_lots = [
             lot for lot in lots if lot.get("average_purchase_price") is not None
         ]
+        unpriced_lots.extend(
+            UnpricedPositionLot(
+                symbol=symbol,
+                instrument=instrument,
+                quantity=lot.get("quantity"),
+            )
+            for lot in lots
+            if lot.get("average_purchase_price") is None
+        )
+        priced_qty = sum((lot.get("quantity") or 0) for lot in cost_lots)
         weighted = sum(
             (lot["average_purchase_price"] * (lot.get("quantity") or 0))
             for lot in cost_lots
         )
-        avg_cost = (
-            (weighted / qty)
-            if (qty and cost_lots)
-            else (cost_lots[0]["average_purchase_price"] if cost_lots else None)
-        )
+        avg_cost = weighted / priced_qty if priced_qty else None
         price = next(
             (lot.get("price") for lot in lots if lot.get("price") is not None), None
         )
@@ -91,7 +102,7 @@ def _net_positions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             }
         )
     netted.sort(key=lambda r: (r["instrument"], r["symbol"]))
-    return netted
+    return NettedPositions(positions=netted, unpriced_lots=unpriced_lots)
 
 
 def sync(config_path: Path, database_url: str | None) -> dict[str, Any]:
@@ -110,7 +121,8 @@ def sync(config_path: Path, database_url: str | None) -> dict[str, Any]:
         client = SnapTradeClientWrapper.from_env()
         for account in syncable:
             aid = account.snaptrade_account_id
-            positions = _net_positions(_account_positions(client, aid))
+            netted = _net_positions(_account_positions(client, aid))
+            positions = netted.positions
             balances = _account_balances(client, aid)
             with conn:  # one transaction per account
                 conn.execute("DELETE FROM positions WHERE account_id = ?", (aid,))
@@ -160,6 +172,7 @@ def sync(config_path: Path, database_url: str | None) -> dict[str, Any]:
                     "settled_cash": balances.get("settled_cash"),
                     "margin_debt": balances.get("margin_debt"),
                     "account_equity": balances.get("account_equity"),
+                    "unpriced_lots": [lot.model_dump() for lot in netted.unpriced_lots],
                 }
             )
     finally:
@@ -197,6 +210,10 @@ def show(database_url: str | None) -> None:
         conn.close()
 
 
+def _format_money(value: float | int | None) -> str:
+    return "n/a" if value is None else f"${value:,}"
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
     paths = InstancePaths.resolve()
@@ -230,9 +247,17 @@ def main(argv: list[str] | None = None) -> int:
     for a in summary["accounts"]:
         print(
             f"- {a['name']} ({a['role']}): {a['equity_rows']} equities, "
-            f"{a['option_rows']} options | equity=${a['account_equity']:,} "
-            f"cash=${a['settled_cash']:,} margin=${a['margin_debt']:,}"
+            f"{a['option_rows']} options | "
+            f"equity={_format_money(a['account_equity'])} "
+            f"cash={_format_money(a['settled_cash'])} "
+            f"margin={_format_money(a['margin_debt'])}"
         )
+        for lot in a["unpriced_lots"]:
+            print(
+                "  warning: cost basis unavailable for "
+                f"{lot['quantity']} {lot['symbol']} {lot['instrument']} units",
+                file=sys.stderr,
+            )
     if not summary["accounts"]:
         print("- no syncable accounts (check config role/enabled)")
     return 0

--- a/src/integrations/snaptrade/sync_transactions_db.py
+++ b/src/integrations/snaptrade/sync_transactions_db.py
@@ -7,9 +7,11 @@ Replaces the retired Google Sheets Transactions tab. Target is DATABASE_URL
     uv run python -m src.integrations.snaptrade.sync_transactions_db          # sync
     uv run python -m src.integrations.snaptrade.sync_transactions_db --show   # summary
 
-Accumulate semantics: transactions are history, so rows are INSERTed and never
-deleted. A UNIQUE natural key (account+date+type+amount+symbol+quantity+desc)
-makes re-runs idempotent — only genuinely new activities are added.
+Accumulate semantics: transaction history is append-only outside the identity
+migration. The UNIQUE key uses SnapTrade's activity identity. On the first sync,
+matching legacy natural keys are updated in place. A redundant legacy row is
+removed only if its provider-keyed replacement already exists. Re-running the
+migration is a no-op.
 
 Expense-Tracker routing is intentionally NOT implemented: SnapTrade activities
 carry no DEBIT CARD PURCHASE records (types are BUY/SELL/DIVIDEND/JOURNALED/
@@ -28,7 +30,12 @@ from pathlib import Path
 from typing import Any
 
 from src.config.instance_paths import InstancePaths, _db_path, load_instance_env
-from src.integrations.snaptrade.client import SnapTradeAPIError, SnapTradeClientWrapper
+from src.integrations.snaptrade.client import (
+    SnapTradeAPIError,
+    SnapTradeClientWrapper,
+    SnapTradeDataError,
+    canonical_activity_date,
+)
 from src.integrations.snaptrade.models import SnapTradeAccountsConfig
 
 _SCHEMA = """
@@ -50,11 +57,15 @@ CREATE INDEX IF NOT EXISTS idx_txn_type ON transactions(type);
 
 
 def _dedupe_key(account_id: str, a: dict[str, Any]) -> str:
-    """Natural key that stays stable across re-runs but keeps distinct rows.
+    """Provider identity key that keeps identical executions distinct."""
+    activity_id = a.get("id")
+    if activity_id is None or not str(activity_id).strip():
+        raise ValueError("Normalized SnapTrade activity is missing id")
+    return f"snaptrade|{account_id}|{str(activity_id).strip()}"
 
-    Coarser than the Sheet's date|type|amount would collide same-day dividends
-    of equal size across symbols, so symbol/quantity/description are included.
-    """
+
+def _natural_dedupe_key(account_id: str, a: dict[str, Any]) -> str:
+    """Return the pre-provider-identity key for idempotent row migration."""
     parts = [
         account_id,
         str(a.get("date") or ""),
@@ -65,6 +76,69 @@ def _dedupe_key(account_id: str, a: dict[str, Any]) -> str:
         str(a.get("description") or ""),
     ]
     return "|".join(parts)
+
+
+def _migrate_natural_dedupe_keys(
+    connection: sqlite3.Connection,
+    account_id: str,
+    activities: list[dict[str, Any]],
+) -> int:
+    """Replace matching legacy keys with deterministic provider identity keys."""
+    replacements: dict[str, list[tuple[str, str]]] = {}
+    for activity in activities:
+        replacements.setdefault(_natural_dedupe_key(account_id, activity), []).append(
+            (_dedupe_key(account_id, activity), str(activity["date"]))
+        )
+
+    migrated = 0
+    legacy_rows = connection.execute(
+        "SELECT rowid, date, type, symbol, description, amount, quantity, currency "
+        "FROM transactions WHERE account_id = ? AND dedupe_key NOT LIKE 'snaptrade|%'",
+        (account_id,),
+    ).fetchall()
+    for legacy_row in legacy_rows:
+        try:
+            legacy_date = canonical_activity_date(legacy_row[1]).isoformat()
+        except SnapTradeDataError:
+            continue
+        legacy_activity = {
+            "date": legacy_date,
+            "type": legacy_row[2],
+            "symbol": legacy_row[3],
+            "description": legacy_row[4],
+            "amount": legacy_row[5],
+            "quantity": legacy_row[6],
+            "currency": legacy_row[7],
+        }
+        candidates = replacements.get(
+            _natural_dedupe_key(account_id, legacy_activity), []
+        )
+        if not candidates:
+            continue
+        target = next(
+            (
+                candidate
+                for candidate in sorted(set(candidates))
+                if connection.execute(
+                    "SELECT 1 FROM transactions WHERE dedupe_key = ?",
+                    (candidate[0],),
+                ).fetchone()
+                is None
+            ),
+            None,
+        )
+        if target is None:
+            connection.execute(
+                "DELETE FROM transactions WHERE rowid = ?",
+                (legacy_row[0],),
+            )
+        else:
+            connection.execute(
+                "UPDATE transactions SET dedupe_key = ?, date = ? WHERE rowid = ?",
+                (target[0], target[1], legacy_row[0]),
+            )
+        migrated += 1
+    return migrated
 
 
 def sync(config_path: Path, database_url: str | None) -> dict[str, Any]:
@@ -84,8 +158,9 @@ def sync(config_path: Path, database_url: str | None) -> dict[str, Any]:
         for account in syncable:
             aid = account.snaptrade_account_id
             activities = client.get_activities(aid)
-            before = conn.total_changes
             with conn:
+                migrated = _migrate_natural_dedupe_keys(conn, aid, activities)
+                before = conn.total_changes
                 conn.executemany(
                     "INSERT OR IGNORE INTO transactions "
                     "(account_id, date, type, symbol, description, amount, quantity, "
@@ -115,6 +190,7 @@ def sync(config_path: Path, database_url: str | None) -> dict[str, Any]:
                     "fetched": len(activities),
                     "inserted": inserted,
                     "skipped_duplicates": len(activities) - inserted,
+                    "migrated_legacy_keys": migrated,
                 }
             )
     finally:
@@ -139,7 +215,8 @@ def show(database_url: str | None) -> None:
             "SELECT type, COUNT(*) n, ROUND(SUM(amount),2) total FROM transactions "
             "GROUP BY type ORDER BY n DESC"
         ):
-            print(f"  {r['type']:14} {r['n']:>5}  net ${r['total']}")
+            activity_type = r["type"] or "unknown"
+            print(f"  {activity_type:14} {r['n']:>5}  net ${r['total']}")
     finally:
         conn.close()
 

--- a/tests/python/test_snaptrade_backlog.py
+++ b/tests/python/test_snaptrade_backlog.py
@@ -1,0 +1,415 @@
+"""Regression coverage for the SnapTrade sync backlog."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.integrations.snaptrade import client as snaptrade_client
+from src.integrations.snaptrade.cli import _account_balances
+from src.integrations.snaptrade.client import SnapTradeAPIError, _summarize_activity
+from src.integrations.snaptrade.sync_db import _net_positions
+from src.integrations.snaptrade.sync_db import main as sync_positions_main
+from src.integrations.snaptrade.sync_db import sync as sync_positions
+from src.integrations.snaptrade.sync_transactions_db import (
+    _SCHEMA as TRANSACTION_SCHEMA,
+)
+from src.integrations.snaptrade.sync_transactions_db import _dedupe_key
+from src.integrations.snaptrade.sync_transactions_db import show as show_transactions
+from src.integrations.snaptrade.sync_transactions_db import sync as sync_transactions
+
+
+def _activity(*, activity_id: str, date: str = "2026-01-03") -> dict[str, Any]:
+    return {
+        "id": activity_id,
+        "type": "BUY",
+        "date": date,
+        "symbol": "AAPL",
+        "amount": -1000.0,
+        "quantity": 10.0,
+        "currency": "USD",
+        "description": "SYNTHETIC BUY",
+        "account": "acct-test",
+    }
+
+
+def _raw_activity(*, activity_id: str | None, trade_date: str) -> dict[str, Any]:
+    activity = {
+        "type": "BUY",
+        "trade_date": trade_date,
+        "symbol": {"symbol": "AAPL"},
+        "amount": -1000.0,
+        "units": 10.0,
+        "currency": {"code": "USD"},
+        "description": "SYNTHETIC BUY",
+        "account": {"id": "acct-test"},
+    }
+    if activity_id is not None:
+        activity["id"] = activity_id
+    return activity
+
+
+def _legacy_dedupe_key(account_id: str, activity: dict[str, Any]) -> str:
+    parts = [
+        account_id,
+        str(activity.get("date") or ""),
+        str(activity.get("type") or ""),
+        str(activity.get("amount") if activity.get("amount") is not None else ""),
+        str(activity.get("symbol") or ""),
+        str(activity.get("quantity") if activity.get("quantity") is not None else ""),
+        str(activity.get("description") or ""),
+    ]
+    return "|".join(parts)
+
+
+def _write_routing_config(path: Path) -> None:
+    path.write_text(
+        "accounts:\n"
+        "- snaptrade_account_id: acct-test\n"
+        "  name: Synthetic account\n"
+        "  role: taxable_margin\n"
+        "  enabled: true\n",
+        encoding="utf-8",
+    )
+
+
+def test_activity_identity_distinguishes_identical_executions() -> None:
+    first = _activity(activity_id="execution-1")
+    second = _activity(activity_id="execution-2")
+
+    assert _dedupe_key("acct-test", first) != _dedupe_key("acct-test", second)
+
+
+def test_activity_dates_normalize_equivalent_timezone_shapes() -> None:
+    local = _summarize_activity(
+        _raw_activity(
+            activity_id="execution-1",
+            trade_date="2026-01-03T23:30:00-06:00",
+        )
+    )
+    utc = _summarize_activity(
+        _raw_activity(
+            activity_id="execution-1",
+            trade_date="2026-01-04T05:30:00Z",
+        )
+    )
+
+    assert local["id"] == utc["id"] == "execution-1"
+    assert local["date"] == utc["date"] == "2026-01-04"
+
+
+@pytest.mark.parametrize("invalid_date", ["01/03/2026", "2026-01-03T12:00:00"])
+def test_activity_date_rejects_non_iso_external_shape(invalid_date: str) -> None:
+    with pytest.raises(SnapTradeAPIError, match="date"):
+        _summarize_activity(
+            _raw_activity(activity_id="execution-1", trade_date=invalid_date)
+        )
+
+
+def test_activity_missing_id_uses_stable_fallback() -> None:
+    raw = _raw_activity(activity_id=None, trade_date="2026-01-03")
+
+    first = _summarize_activity(raw)
+    second = _summarize_activity(dict(reversed(list(raw.items()))))
+
+    assert first["id"].startswith("fallback:")
+    assert first["id"] == second["id"]
+
+
+def test_repeat_sync_migrates_natural_key_and_keeps_both_executions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    activities = [
+        _activity(activity_id="execution-1"),
+        _activity(activity_id="execution-2"),
+    ]
+
+    class ActivityClient:
+        @classmethod
+        def from_env(cls) -> ActivityClient:
+            return cls()
+
+        def get_activities(self, account_id: str) -> list[dict[str, Any]]:
+            assert account_id == "acct-test"
+            return activities
+
+    monkeypatch.setattr(
+        "src.integrations.snaptrade.sync_transactions_db.SnapTradeClientWrapper",
+        ActivityClient,
+    )
+    config_path = tmp_path / "snaptrade-accounts.yaml"
+    database_path = tmp_path / "family_office.db"
+    _write_routing_config(config_path)
+
+    legacy_activity = {
+        **activities[0],
+        "date": "2026-01-02T19:00:00-06:00",
+    }
+    with sqlite3.connect(database_path) as connection:
+        connection.executescript(TRANSACTION_SCHEMA)
+        connection.execute(
+            "INSERT INTO transactions "
+            "(account_id, date, type, symbol, description, amount, quantity, "
+            "currency, dedupe_key, synced_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (
+                "acct-test",
+                legacy_activity["date"],
+                legacy_activity["type"],
+                legacy_activity["symbol"],
+                legacy_activity["description"],
+                legacy_activity["amount"],
+                legacy_activity["quantity"],
+                legacy_activity["currency"],
+                _legacy_dedupe_key("acct-test", legacy_activity),
+                "2026-01-01T00:00:00+00:00",
+            ),
+        )
+
+    first = sync_transactions(config_path, str(database_path))
+    second = sync_transactions(config_path, str(database_path))
+
+    with sqlite3.connect(database_path) as connection:
+        persisted = {
+            (row[0], row[1])
+            for row in connection.execute(
+                "SELECT dedupe_key, date FROM transactions ORDER BY dedupe_key"
+            )
+        }
+
+    assert persisted == {
+        (_dedupe_key("acct-test", activities[0]), "2026-01-03"),
+        (_dedupe_key("acct-test", activities[1]), "2026-01-03"),
+    }
+    assert first["accounts"][0]["migrated_legacy_keys"] == 1
+    assert first["accounts"][0]["inserted"] == 1
+    assert second["accounts"][0]["migrated_legacy_keys"] == 0
+    assert second["accounts"][0]["inserted"] == 0
+
+
+def test_net_positions_divides_cost_by_priced_quantity_and_surfaces_gap() -> None:
+    result = _net_positions(
+        [
+            {
+                "symbol": "AAPL",
+                "instrument": "equity",
+                "quantity": 10.0,
+                "average_purchase_price": 100.0,
+                "price": 110.0,
+            },
+            {
+                "symbol": "AAPL",
+                "instrument": "equity",
+                "quantity": 10.0,
+                "average_purchase_price": None,
+                "price": 110.0,
+            },
+        ]
+    )
+
+    assert result.positions[0]["quantity"] == 20.0
+    assert result.positions[0]["avg_cost"] == 100.0
+    assert result.unpriced_lots[0].model_dump() == {
+        "symbol": "AAPL",
+        "instrument": "equity",
+        "quantity": 10.0,
+    }
+
+
+def test_position_sync_returns_unpriced_lots_to_caller(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class PositionClient:
+        @classmethod
+        def from_env(cls) -> PositionClient:
+            return cls()
+
+        def get_positions(self, account_id: str) -> list[dict[str, Any]]:
+            assert account_id == "acct-test"
+            return [
+                {
+                    "symbol": "AAPL",
+                    "instrument": "equity",
+                    "quantity": 10.0,
+                    "average_purchase_price": 100.0,
+                    "price": 110.0,
+                },
+                {
+                    "symbol": "AAPL",
+                    "instrument": "equity",
+                    "quantity": 10.0,
+                    "average_purchase_price": None,
+                    "price": 110.0,
+                },
+            ]
+
+        def get_options(self, account_id: str) -> list[dict[str, Any]]:
+            assert account_id == "acct-test"
+            return []
+
+        def get_balances(self, account_id: str) -> list[dict[str, Any]]:
+            assert account_id == "acct-test"
+            return [{"currency": "USD", "cash": 0.0, "buying_power": 0.0}]
+
+        def get_account_equity(self, account_id: str) -> float:
+            assert account_id == "acct-test"
+            return 2200.0
+
+    monkeypatch.setattr(
+        "src.integrations.snaptrade.sync_db.SnapTradeClientWrapper",
+        PositionClient,
+    )
+    config_path = tmp_path / "snaptrade-accounts.yaml"
+    database_path = tmp_path / "family_office.db"
+    _write_routing_config(config_path)
+
+    summary = sync_positions(config_path, str(database_path))
+
+    assert summary["accounts"][0]["unpriced_lots"] == [
+        {"symbol": "AAPL", "instrument": "equity", "quantity": 10.0}
+    ]
+    with sqlite3.connect(database_path) as connection:
+        assert connection.execute(
+            "SELECT quantity, avg_cost FROM positions WHERE symbol = 'AAPL'"
+        ).fetchone() == (20.0, 100.0)
+
+
+class _BalanceClient:
+    def __init__(
+        self,
+        balances: list[dict[str, Any]],
+        *,
+        equity: float | None = 1000.0,
+        price: float | None = 100.0,
+    ) -> None:
+        self.balances = balances
+        self.equity = equity
+        self.price = price
+
+    def get_balances(self, account_id: str) -> list[dict[str, Any]]:
+        assert account_id == "acct-test"
+        return self.balances
+
+    def get_account_equity(self, account_id: str) -> float | None:
+        assert account_id == "acct-test"
+        return self.equity
+
+    def get_positions(self, account_id: str) -> list[dict[str, Any]]:
+        assert account_id == "acct-test"
+        return [
+            {
+                "symbol": "AAPL",
+                "instrument": "equity",
+                "quantity": 10.0,
+                "price": self.price,
+            }
+        ]
+
+    def get_options(self, account_id: str) -> list[dict[str, Any]]:
+        assert account_id == "acct-test"
+        return []
+
+
+def test_account_balances_selects_requested_currency() -> None:
+    client = _BalanceClient(
+        [
+            {"currency": "EUR", "cash": 25.0, "buying_power": 30.0},
+            {"currency": "USD", "cash": 50.0, "buying_power": 60.0},
+        ]
+    )
+
+    balance = _account_balances(client, "acct-test", currency="USD")
+
+    assert balance["currency"] == "USD"
+    assert balance["settled_cash"] == 50.0
+    assert balance["buying_power"] == 60.0
+
+
+def test_account_balances_rejects_single_non_requested_currency() -> None:
+    client = _BalanceClient([{"currency": "EUR", "cash": 25.0, "buying_power": 30.0}])
+
+    with pytest.raises(SnapTradeAPIError) as error:
+        _account_balances(client, "acct-test", currency="USD")
+
+    assert type(error.value).__name__ == "BalanceCurrencyMismatchError"
+
+
+def test_margin_debt_rejects_missing_equity_with_typed_failure() -> None:
+    stocks = [{"symbol": "AAPL", "price": 100.0, "quantity": 10.0}]
+
+    with pytest.raises(SnapTradeAPIError) as error:
+        snaptrade_client.derive_margin_debt(stocks, [], equity=None)
+
+    assert type(error.value).__name__ == "MissingAccountEquityError"
+
+
+def test_margin_debt_rejects_missing_position_mark_with_typed_failure() -> None:
+    stocks = [{"symbol": "AAPL", "price": None, "quantity": 10.0}]
+
+    with pytest.raises(SnapTradeAPIError) as error:
+        snaptrade_client.derive_margin_debt(stocks, [], equity=1000.0)
+
+    assert type(error.value).__name__ == "MissingPositionMarkError"
+
+
+def test_position_sync_cli_renders_nullable_money_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        "src.integrations.snaptrade.sync_db.sync",
+        lambda config_path, database_url: {
+            "db": str(tmp_path / "family_office.db"),
+            "synced_at": "2026-01-01T00:00:00+00:00",
+            "accounts": [
+                {
+                    "name": "Synthetic account",
+                    "role": "taxable_margin",
+                    "equity_rows": 1,
+                    "option_rows": 0,
+                    "account_equity": None,
+                    "settled_cash": None,
+                    "margin_debt": None,
+                    "unpriced_lots": [],
+                }
+            ],
+        },
+    )
+
+    assert sync_positions_main([]) == 0
+
+    output = capsys.readouterr().out
+    assert "equity=n/a cash=n/a margin=n/a" in output
+
+
+def test_transaction_show_renders_nullable_type(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    database_path = tmp_path / "family_office.db"
+    with sqlite3.connect(database_path) as connection:
+        connection.executescript(TRANSACTION_SCHEMA)
+        connection.execute(
+            "INSERT INTO transactions "
+            "(account_id, date, type, symbol, description, amount, quantity, "
+            "currency, dedupe_key, synced_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (
+                "acct-test",
+                "2026-01-03",
+                None,
+                None,
+                None,
+                None,
+                None,
+                "USD",
+                "snaptrade|acct-test|execution-1",
+                "2026-01-01T00:00:00+00:00",
+            ),
+        )
+
+    show_transactions(str(database_path))
+
+    assert "unknown" in capsys.readouterr().out

--- a/tests/python/test_snaptrade_db_sync.py
+++ b/tests/python/test_snaptrade_db_sync.py
@@ -34,7 +34,7 @@ def test_net_positions_sums_lots_and_weights_cost() -> None:
             "price": 100.0,
         },
     ]
-    out = _net_positions(rows)
+    out = _net_positions(rows).positions
     assert len(out) == 1
     row = out[0]
     assert row["quantity"] == 105.381 + 1.631
@@ -64,13 +64,14 @@ def test_net_positions_keeps_distinct_symbols_and_instruments() -> None:
             "average_purchase_price": 4.6,
         },
     ]
-    out = _net_positions(rows)
+    out = _net_positions(rows).positions
     assert len({(r["symbol"], r["instrument"]) for r in out}) == 3
 
 
 def test_dedupe_key_stable_and_distinguishes_same_day_dividends() -> None:
-    """Same activity -> same key (idempotent); different symbol -> different key."""
+    """Same provider activity stays idempotent; distinct activity ids do not collide."""
     a = {
+        "id": "activity-1",
         "date": "2026-01-02",
         "type": "DIVIDEND",
         "amount": 12.5,
@@ -78,7 +79,7 @@ def test_dedupe_key_stable_and_distinguishes_same_day_dividends() -> None:
         "quantity": 0.0,
         "description": "DIV",
     }
-    b = {**a, "symbol": "JEPQ"}  # same day, same amount, different holding
+    b = {**a, "id": "activity-2", "symbol": "JEPQ"}
     assert _dedupe_key("acct1", a) == _dedupe_key("acct1", a)
     assert _dedupe_key("acct1", a) != _dedupe_key("acct1", b)
 

--- a/tests/python/test_snaptrade_integration.py
+++ b/tests/python/test_snaptrade_integration.py
@@ -482,16 +482,18 @@ def test_occ_to_fidelity_symbol_conversion():
 
 def test_derive_margin_debt_math():
     """Margin debt = gross long MV (options x100) minus net equity."""
-    from src.integrations.snaptrade.client import derive_margin_debt
+    from src.integrations.snaptrade.client import (
+        MissingAccountEquityError,
+        derive_margin_debt,
+    )
 
     stocks = [{"price": 100, "quantity": 10}]  # 1000
     options = [{"price": 2.0, "quantity": 3}]  # 2*3*100 = 600
     debt, gross = derive_margin_debt(stocks, options, equity=1200.0)
     assert gross == 1600.0
     assert debt == 400.0
-    # unknown equity -> debt None, gross still computed
-    debt2, gross2 = derive_margin_debt(stocks, options, equity=None)
-    assert debt2 is None and gross2 == 1600.0
+    with pytest.raises(MissingAccountEquityError):
+        derive_margin_debt(stocks, options, equity=None)
     # net-cash account (equity > gross) clamps to 0, never a negative loan
     debt3, _ = derive_margin_debt(stocks, options, equity=2000.0)
     assert debt3 == 0.0
@@ -539,6 +541,7 @@ def test_summarize_activity_emits_stable_shape():
     record = _summarize_activity(_ACTIVITY_FIXTURE[2])  # the TSLA buy
 
     assert record == {
+        "id": "a3",
         "type": "BUY",
         "date": "2026-01-03",
         "symbol": "TSLA",


### PR DESCRIPTION
## Problem

Five SnapTrade sync defects from the backlog. `dedupe_key` collapsed two genuine same-day executions into one row (#116). Activity identity and dates were not canonical across sync runs (#101). Weighted cost basis divided by every lot's quantity while summing only priced lots, understating basis (#117). Balance selection could accept a sole non-USD row and margin-debt derivation could use missing equity or marks (#106). The sync CLI crashed on legitimate null money fields (#119, SnapTrade item).

## Fix

- The unique key is now `snaptrade|<account>|<activity id>` with a stable SHA-256 fallback when the provider omits an id. On the next sync, legacy natural keys are migrated in place inside the same SQLite transaction; a legacy row is deleted only when its provider-keyed replacement already exists, and rows SnapTrade no longer returns are left untouched. Re-running is a no-op. No DDL changed.
- One `SnapTradeActivity` model and `canonical_activity_date` define the contract: `YYYY-MM-DD` or a timezone-aware ISO datetime normalized to a UTC date; naive or non-ISO dates raise `SnapTradeDataError`.
- Cost basis divides by priced quantity; `NettedPositions` carries the unpriced lots to the caller and the CLI warns on them.
- Balance selection takes an explicit currency (USD default) and rejects mismatches including the single-row case. Missing equity or marks raise typed errors and block the sync.
- CLI renders null money as `n/a` and null type as `unknown`.

Sync summaries gain `migrated_legacy_keys` and `unpriced_lots`.

## Evidence

Thirteen new tests in `test_snaptrade_backlog.py` against real SQLite, each seen red first (key collision assertion, KeyError id, DID NOT RAISE, NoneType format error). Ruff, mypy, and the non-integration suite (1127 passed, coverage 82.34%) are clean.

Closes #116, closes #117, closes #101, closes #106.

Changes made by gpt-5.6-sol (Codex, herdr worker) with review and commit by Claude Fable 5.1 in Claude Code.