### PR TITLE
fix(buy-ticket): fail closed on NAV, margin rate, and Layer 3 ITC; model persistence apart from notification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - anthropic>=0.107.1
           - pydantic>=2.10.6
           - types-requests
           - types-PyYAML

--- a/buy_ticket_agent/config.py
+++ b/buy_ticket_agent/config.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict
 
-from src.config.instance_paths import InstancePaths
+from src.analysis.margin_metrics import parse_rate
+from src.config.instance_paths import InstancePaths, load_instance_env
 
 
 class SmokePaths(BaseModel):
@@ -53,3 +54,13 @@ def get_env(name: str, default: str | None = None) -> str | None:
         return None
     value = value.strip()
     return value or None
+
+
+def resolve_annual_margin_rate(paths: InstancePaths | None = None) -> float | None:
+    """Load the authoritative annual margin rate from the instance environment."""
+    instance_paths = paths or InstancePaths.resolve()
+    load_instance_env(instance_paths, override=False)
+    configured_rate = get_env("FG_MARGIN_INTEREST_RATE_DECIMAL") or get_env(
+        "FG_MARGIN_INTEREST_RATE"
+    )
+    return parse_rate(configured_rate) if configured_rate is not None else None

--- a/buy_ticket_agent/guardrails.py
+++ b/buy_ticket_agent/guardrails.py
@@ -6,7 +6,12 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState
+from buy_ticket_agent.ticket_models import (
+    BuyTicket,
+    GuardrailContext,
+    PortfolioState,
+    TicketProposal,
+)
 
 CONCENTRATION_LIMIT = 0.30
 MIN_MARGIN_COVERAGE = 2.0
@@ -24,7 +29,7 @@ class GuardrailResult(BaseModel):
     violations: list[str]
 
 
-def _deployment_by_ticker(ticket: BuyTicket) -> dict[str, float]:
+def _deployment_by_ticker(ticket: TicketProposal) -> dict[str, float]:
     deployments: dict[str, float] = {}
     for allocation in ticket.allocations:
         deployments[allocation.ticker] = (
@@ -33,68 +38,85 @@ def _deployment_by_ticker(ticket: BuyTicket) -> dict[str, float]:
     return deployments
 
 
-def _post_deployment_portfolio_value(
-    ticket: BuyTicket,
-    portfolio: PortfolioState,
-) -> float:
-    externally_funded_deployment = max(
-        ticket.deployment_amount - portfolio.cash_available,
-        0.0,
-    )
-    return portfolio.portfolio_value + externally_funded_deployment
+def _pre_borrow_equity_nav(portfolio: PortfolioState) -> float | None:
+    """Return the sole concentration denominator when it is authoritative."""
+    nav = portfolio.portfolio_value
+    return nav if nav is not None and nav > 0.0 else None
 
 
 def _first_concentration_violation(
-    ticket: BuyTicket,
+    ticket: TicketProposal,
     portfolio: PortfolioState,
 ) -> str | None:
-    portfolio_after = _post_deployment_portfolio_value(ticket, portfolio)
-    if portfolio_after <= 0.0:
-        return None
+    equity_nav = _pre_borrow_equity_nav(portfolio)
+    if equity_nav is None:
+        return "equity_nav_unavailable"
 
     for ticker, deployment in _deployment_by_ticker(ticket).items():
         existing = portfolio.current_positions.get(ticker, 0.0)
-        concentration = (existing + deployment) / portfolio_after
+        concentration = (existing + deployment) / equity_nav
         if concentration > CONCENTRATION_LIMIT:
             return "concentration>30%"
     return None
 
 
-def _margin_coverage_violation(portfolio: PortfolioState) -> str | None:
-    if portfolio.monthly_margin_interest == 0.0:
+def _projected_margin_borrowing(
+    ticket: TicketProposal,
+    portfolio: PortfolioState,
+) -> float:
+    return max(ticket.deployment_amount - portfolio.cash_available, 0.0)
+
+
+def _margin_coverage_violation(
+    ticket: TicketProposal,
+    context: GuardrailContext,
+) -> str | None:
+    portfolio = context.portfolio
+    projected_borrowing = _projected_margin_borrowing(ticket, portfolio)
+    if projected_borrowing > 0.0 and context.annual_margin_rate is None:
+        return "margin_rate_unavailable"
+
+    projected_monthly_interest = portfolio.monthly_margin_interest
+    if context.annual_margin_rate is not None:
+        projected_monthly_interest += (
+            projected_borrowing * context.annual_margin_rate / 12
+        )
+    if projected_monthly_interest == 0.0:
         return None
-    coverage = portfolio.monthly_dividend_income / portfolio.monthly_margin_interest
+    coverage = portfolio.monthly_dividend_income / projected_monthly_interest
     if coverage < MIN_MARGIN_COVERAGE:
         return "coverage<2x"
     return None
 
 
-def _itc_risk_violation(ticket: BuyTicket) -> str | None:
-    if ticket.itc_applicability == "supported" and ticket.itc_risk_score is None:
-        # ITC was declared applicable but no score arrived (e.g. ITC CLI failure).
-        # Fail-safe: block rather than silently skip the guardrail.
-        return "itc_risk_score_missing"
-    if ticket.itc_risk_score is None:
-        return None
-    if ticket.itc_risk_score >= MAX_ITC_RISK:
+def _itc_risk_violation(itc_risk_score: float) -> str | None:
+    if itc_risk_score >= MAX_ITC_RISK:
         return "itc_risk>=0.7"
     return None
 
 
 def check(
-    ticket: BuyTicket | dict,
-    portfolio: PortfolioState | dict,
+    ticket: TicketProposal | dict,
+    context: GuardrailContext | dict,
 ) -> GuardrailResult:
-    """Evaluate non-negotiable post-LLM guardrails against a generated ticket."""
-    parsed_ticket = BuyTicket.model_validate(ticket)
-    parsed_portfolio = PortfolioState.model_validate(portfolio)
+    """Evaluate a model proposal using only trusted guardrail context."""
+    proposal = TicketProposal.model_validate(ticket)
+    parsed_context = GuardrailContext.model_validate(context)
+    portfolio = parsed_context.portfolio
+    parsed_ticket = BuyTicket.model_validate(
+        {
+            **proposal.model_dump(mode="python"),
+            "itc_applicability": "supported",
+            "itc_risk_score": parsed_context.itc_risk_score,
+        }
+    )
 
     violations = [
         violation
         for violation in (
-            _first_concentration_violation(parsed_ticket, parsed_portfolio),
-            _margin_coverage_violation(parsed_portfolio),
-            _itc_risk_violation(parsed_ticket),
+            _first_concentration_violation(parsed_ticket, portfolio),
+            _margin_coverage_violation(proposal, parsed_context),
+            _itc_risk_violation(parsed_context.itc_risk_score),
         )
         if violation is not None
     ]

--- a/buy_ticket_agent/main.py
+++ b/buy_ticket_agent/main.py
@@ -9,6 +9,9 @@ from dataclasses import asdict
 
 from buy_ticket_agent.pipeline import run_smoke_for_cli
 from buy_ticket_agent.secrets import SecretAccessError
+from src.utils.log import get_logger
+
+logger = get_logger(__name__)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -36,11 +39,15 @@ def main(argv: list[str] | None = None) -> int:
     try:
         result = run_smoke_for_cli()
     except SecretAccessError as exc:
-        print(f"Secret access blocker: {exc}", file=sys.stderr)
+        logger.error("buy_ticket_secret_access_failed", error=str(exc))
         return 1
 
-    print(json.dumps(asdict(result), indent=2, sort_keys=True))
-    return 0 if result.status == "completed" else 1
+    sys.stdout.write(json.dumps(asdict(result), indent=2, sort_keys=True) + "\n")
+    if result.status != "completed":
+        return 1
+    if result.notification is not None and result.notification.status == "failed":
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/buy_ticket_agent/notifier.py
+++ b/buy_ticket_agent/notifier.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 from urllib.parse import quote
 
 import requests
@@ -14,7 +15,7 @@ from buy_ticket_agent.config import NotificationConfig
 class NotificationResult:
     """Result envelope for a notification attempt."""
 
-    status: str
+    status: Literal["sent", "skipped", "failed"]
     source: str | None
     error: str | None = None
 

--- a/buy_ticket_agent/pipeline.py
+++ b/buy_ticket_agent/pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import subprocess
@@ -52,16 +53,24 @@ class CliEnvelope:
 
 
 @dataclass(frozen=True)
+class DraftPersistenceResult:
+    """Durability outcome for the smoke draft, independent of delivery."""
+
+    status: Literal["created", "reused", "not-created"]
+
+
+@dataclass(frozen=True)
 class SmokeResult:
     """Result envelope returned by a smoke run."""
 
     run_id: str
     ticket_id: str | None
-    status: str
+    status: Literal["completed", "layer3_failed"]
     draft_path: str | None
     log_path: str
     state_db: str
     notification: NotificationResult | None
+    persistence: DraftPersistenceResult | None = None
 
 
 @dataclass(frozen=True)
@@ -492,6 +501,25 @@ def _trigger_context_from_env() -> dict[str, str] | None:
     return context
 
 
+def _smoke_run_id(
+    now: datetime,
+    trigger_context: dict[str, str] | None,
+) -> str:
+    """Derive one logical run identity for each upstream trigger."""
+    if trigger_context is not None:
+        source = trigger_context.get("source")
+        transaction_key = trigger_context.get("transaction_key")
+        if source and transaction_key:
+            identity = json.dumps(
+                [source, transaction_key],
+                ensure_ascii=True,
+                separators=(",", ":"),
+            )
+            digest = hashlib.sha256(identity.encode()).hexdigest()[:16]
+            return f"smoke-trigger-{digest}"
+    return f"smoke-{now:%Y%m%d}-{uuid4().hex[:8]}"
+
+
 def run_layer3_smoke_cli(project_root: Path) -> CliEnvelope:
     """Invoke the existing ITC Risk CLI once for the smoke path."""
     command_args = (
@@ -549,6 +577,36 @@ def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
+def _load_persisted_smoke(
+    draft_path: Path,
+    log_path: Path,
+    *,
+    run_id: str,
+    ticket_id: str,
+) -> tuple[str, CliEnvelope]:
+    """Load and validate the durable inputs needed for a notification retry."""
+    try:
+        draft = json.loads(draft_path.read_text())
+        log = json.loads(log_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("Persisted smoke artifacts are unreadable") from exc
+    if not isinstance(draft, dict) or not isinstance(log, dict):
+        raise ValueError("Persisted smoke artifacts must be JSON objects")
+    if draft.get("run_id") != run_id or draft.get("id") != ticket_id:
+        raise ValueError("Persisted smoke draft identity does not match trigger")
+    created_at = draft.get("created_at")
+    layer3 = log.get("layer3")
+    if not isinstance(created_at, str) or not isinstance(layer3, dict):
+        raise ValueError("Persisted smoke artifacts are incomplete")
+    try:
+        cli_result = CliEnvelope(**layer3)
+    except TypeError as exc:
+        raise ValueError("Persisted Layer 3 result is malformed") from exc
+    if cli_result.status != "succeeded":
+        raise ValueError("Persisted smoke draft lacks successful Layer 3 evidence")
+    return created_at, cli_result
+
+
 def _make_ticket_payload(
     *,
     run_id: str,
@@ -586,31 +644,41 @@ def run_smoke(
     """Run the AOJ-458 end-to-end smoke path."""
     paths = _resolve_smoke_paths(instance_paths, project_root)
     now = _utc_now()
-    created_at = now.isoformat()
-    run_id = f"smoke-{now:%Y%m%d}-{uuid4().hex[:8]}"
-    ticket_id = f"ticket-{run_id}"
-
     notification_config = resolve_notification_config()
     trigger_context = _trigger_context_from_env()
+    created_at = now.isoformat()
+    run_id = _smoke_run_id(now, trigger_context)
+    ticket_id = f"ticket-{run_id}"
     initialize_state(paths.state_db)
-    cli_result = run_layer3_smoke_cli(paths.project_root)
 
     draft_path = paths.drafts_dir / f"{run_id}.json"
     log_path = paths.runs_dir / f"{run_id}.json"
     preview = f"{SMOKE_TICKER} shadow draft ready for review"
+    if draft_path.exists():
+        created_at, cli_result = _load_persisted_smoke(
+            draft_path,
+            log_path,
+            run_id=run_id,
+            ticket_id=ticket_id,
+        )
+        persistence = DraftPersistenceResult(status="reused")
+    else:
+        cli_result = run_layer3_smoke_cli(paths.project_root)
+        persistence = DraftPersistenceResult(status="not-created")
 
     if cli_result.status != "succeeded":
-        status = "layer3_failed"
+        failure_status: Literal["layer3_failed"] = "layer3_failed"
         log_payload = {
             "event": "buy_ticket_smoke_run",
             "run_id": run_id,
             "ticket_id": None,
             "created_at": created_at,
-            "status": status,
+            "status": failure_status,
             "draft_path": None,
             "state_db": _relative(paths.state_db, paths.instance_root),
             "trigger": trigger_context,
             "layer3": asdict(cli_result),
+            "persistence": asdict(persistence),
             "notification": None,
         }
         _write_json(log_path, log_payload)
@@ -618,49 +686,49 @@ def run_smoke(
             paths.state_db,
             run_id=run_id,
             created_at=created_at,
-            status=status,
+            status=failure_status,
             log_path=log_path,
         )
         return SmokeResult(
             run_id=run_id,
             ticket_id=None,
-            status=status,
+            status=failure_status,
             draft_path=None,
             log_path=_relative(log_path, paths.instance_root),
             state_db=_relative(paths.state_db, paths.instance_root),
             notification=None,
+            persistence=persistence,
         )
 
-    ticket_payload = _make_ticket_payload(
-        run_id=run_id,
-        ticket_id=ticket_id,
-        created_at=created_at,
-        cli_result=cli_result,
-        trigger_context=trigger_context,
-    )
-    _write_json(draft_path, ticket_payload)
+    if persistence.status == "not-created":
+        ticket_payload = _make_ticket_payload(
+            run_id=run_id,
+            ticket_id=ticket_id,
+            created_at=created_at,
+            cli_result=cli_result,
+            trigger_context=trigger_context,
+        )
+        _write_json(draft_path, ticket_payload)
+        persistence = DraftPersistenceResult(status="created")
 
     notification = push_ticket_preview(
         notification_config,
         ticket_id=ticket_id,
         preview=preview,
     )
-    status = (
-        "completed"
-        if notification.status in {"sent", "skipped"}
-        else "notification_failed"
-    )
+    success_status: Literal["completed"] = "completed"
 
     log_payload = {
         "event": "buy_ticket_smoke_run",
         "run_id": run_id,
         "ticket_id": ticket_id,
         "created_at": created_at,
-        "status": status,
+        "status": success_status,
         "draft_path": _relative(draft_path, paths.instance_root),
         "state_db": _relative(paths.state_db, paths.instance_root),
         "trigger": trigger_context,
         "layer3": asdict(cli_result),
+        "persistence": asdict(persistence),
         "notification": asdict(notification),
     }
     _write_json(log_path, log_payload)
@@ -670,7 +738,7 @@ def run_smoke(
         ticket_id=ticket_id,
         created_at=created_at,
         ticker=SMOKE_TICKER,
-        status=status,
+        status=success_status,
         draft_path=draft_path,
         log_path=log_path,
         preview=preview,
@@ -679,11 +747,12 @@ def run_smoke(
     return SmokeResult(
         run_id=run_id,
         ticket_id=ticket_id,
-        status=status,
+        status=success_status,
         draft_path=_relative(draft_path, paths.instance_root),
         log_path=_relative(log_path, paths.instance_root),
         state_db=_relative(paths.state_db, paths.instance_root),
         notification=notification,
+        persistence=persistence,
     )
 
 

--- a/buy_ticket_agent/ticket_generator.py
+++ b/buy_ticket_agent/ticket_generator.py
@@ -3,17 +3,27 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from buy_ticket_agent.config import resolve_annual_margin_rate
 from buy_ticket_agent.guardrails import GuardrailResult, check
-from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState
+from buy_ticket_agent.ticket_models import (
+    BuyTicket,
+    GuardrailContext,
+    PortfolioState,
+    TicketProposal,
+)
+from src.models.itc_risk_inputs import ITCRiskResponse
 
 DEFAULT_MODEL = "claude-sonnet-4-6"
 TICKET_TOOL_NAME = "emit_buy_ticket"
-SYSTEM_MANAGED_TICKET_FIELDS = frozenset({"advisory_block"})
+SYSTEM_MANAGED_TICKET_FIELDS = frozenset(
+    {"advisory_block", "itc_applicability", "itc_risk_score"}
+)
 FRAMEWORK_DOC_PATHS = (
     "fin-guru/templates/buy-ticket-template.md",
     "fin-guru/data/definitions.md",
@@ -41,6 +51,10 @@ class TicketGenerationResult(BaseModel):
     guardrails: GuardrailResult
     usage: TicketUsage
     model: str = Field(default=DEFAULT_MODEL)
+
+
+class Layer3ITCError(ValueError):
+    """Raised when authoritative ITC evidence cannot support generation."""
 
 
 def _default_client() -> Any:
@@ -96,21 +110,7 @@ def _system_blocks(
 
 
 def _tool_schema() -> dict[str, Any]:
-    input_schema = BuyTicket.model_json_schema()
-    properties = input_schema.get("properties")
-    if isinstance(properties, dict):
-        input_schema["properties"] = {
-            field_name: schema
-            for field_name, schema in properties.items()
-            if field_name not in SYSTEM_MANAGED_TICKET_FIELDS
-        }
-    required = input_schema.get("required")
-    if isinstance(required, list):
-        input_schema["required"] = [
-            field_name
-            for field_name in required
-            if field_name not in SYSTEM_MANAGED_TICKET_FIELDS
-        ]
+    input_schema = TicketProposal.model_json_schema()
     return {
         "name": TICKET_TOOL_NAME,
         "description": "Emit one structured buy-ticket JSON object.",
@@ -171,6 +171,32 @@ def _usage_from_response(response: Any) -> TicketUsage:
     )
 
 
+def _authoritative_itc(bundle: Mapping[str, Any]) -> ITCRiskResponse:
+    """Validate successful Layer 3 ITC evidence before model generation."""
+    itc_result = bundle.get("itc")
+    if not isinstance(itc_result, Mapping):
+        raise Layer3ITCError("Layer 3 ITC result is missing")
+    if itc_result.get("status") != "succeeded" or itc_result.get("returncode") != 0:
+        raise Layer3ITCError("Layer 3 ITC result did not succeed")
+    data = itc_result.get("data")
+    if not isinstance(data, Mapping):
+        raise Layer3ITCError("Layer 3 ITC data is missing")
+    raw_score = data.get("current_risk_score")
+    if isinstance(raw_score, bool) or not isinstance(raw_score, (int, float)):
+        raise Layer3ITCError("Layer 3 ITC risk score is malformed")
+    try:
+        evidence = ITCRiskResponse.model_validate(data)
+    except ValidationError as exc:
+        raise Layer3ITCError("Layer 3 ITC data is malformed") from exc
+
+    primary_ticker = bundle.get("primary_ticker")
+    if not isinstance(primary_ticker, str) or (
+        evidence.symbol != primary_ticker.strip().upper()
+    ):
+        raise Layer3ITCError("Layer 3 ITC symbol does not match primary ticker")
+    return evidence
+
+
 def generate(
     bundle: dict[str, Any],
     portfolio_state: PortfolioState | dict,
@@ -182,6 +208,8 @@ def generate(
 ) -> TicketGenerationResult:
     """Generate a buy-ticket JSON object and enforce hard guardrails."""
     parsed_portfolio = PortfolioState.model_validate(portfolio_state)
+    itc = _authoritative_itc(bundle)
+    annual_margin_rate = resolve_annual_margin_rate()
     anthropic_client = client if client is not None else _default_client()
     root = project_root or Path.cwd()
 
@@ -197,8 +225,22 @@ def generate(
             "disable_parallel_tool_use": True,
         },
     )
-    ticket = BuyTicket.model_validate(_extract_tool_input(response))
-    guardrail_result = check(ticket, parsed_portfolio)
+    tool_input = _extract_tool_input(response)
+    proposal = TicketProposal.model_validate(
+        {
+            field_name: value
+            for field_name, value in tool_input.items()
+            if field_name not in SYSTEM_MANAGED_TICKET_FIELDS
+        }
+    )
+    guardrail_result = check(
+        proposal,
+        GuardrailContext(
+            portfolio=parsed_portfolio,
+            itc_risk_score=itc.current_risk_score,
+            annual_margin_rate=annual_margin_rate,
+        ),
+    )
     return TicketGenerationResult(
         ticket=guardrail_result.ticket,
         guardrails=guardrail_result,

--- a/buy_ticket_agent/ticket_models.py
+++ b/buy_ticket_agent/ticket_models.py
@@ -32,8 +32,8 @@ class TicketAllocation(BaseModel):
         return normalized
 
 
-class BuyTicket(BaseModel):
-    """Structured JSON representation of the buy-ticket template."""
+class TicketProposal(BaseModel):
+    """Model-authored buy-ticket fields before trusted guardrail enrichment."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -46,8 +46,6 @@ class BuyTicket(BaseModel):
     cash_available: float = Field(ge=0.0)
     remaining_cash_buffer: float
     price_snapshot_as_of: str
-    itc_applicability: Literal["supported", "unsupported", "not-run"]
-    itc_risk_score: float | None = Field(default=None, ge=0.0, le=1.0)
     allocations: list[TicketAllocation]
     strategy_rationale: list[str]
     risk_notes: list[str]
@@ -55,7 +53,6 @@ class BuyTicket(BaseModel):
     assumptions: list[str]
     progress_tracking: str
     educational_notice: str
-    advisory_block: str | None = None
 
     @field_validator(
         "strategy_name",
@@ -84,7 +81,7 @@ class BuyTicket(BaseModel):
         return value
 
     @model_validator(mode="after")
-    def require_allocations_and_notes(self) -> BuyTicket:
+    def require_allocations_and_notes(self) -> TicketProposal:
         """Ensure the ticket carries the minimum template sections."""
         if not self.allocations:
             raise ValueError("allocations are required")
@@ -102,12 +99,24 @@ class BuyTicket(BaseModel):
         return self
 
 
+class BuyTicket(TicketProposal):
+    """Final buy ticket enriched with system-owned guardrail fields."""
+
+    itc_applicability: Literal["supported"] = "supported"
+    itc_risk_score: float = Field(ge=0.0, le=1.0)
+    advisory_block: str | None = None
+
+
 class PortfolioState(BaseModel):
     """Portfolio context needed for hard guardrail checks."""
 
     model_config = ConfigDict(extra="forbid")
 
-    portfolio_value: float = Field(ge=0.0)
+    portfolio_value: float | None = Field(
+        default=None,
+        allow_inf_nan=False,
+        description="Authoritative pre-borrow equity NAV",
+    )
     cash_available: float = Field(ge=0.0)
     monthly_dividend_income: float = Field(ge=0.0)
     monthly_margin_interest: float = Field(ge=0.0)
@@ -127,3 +136,18 @@ class PortfolioState(BaseModel):
                 raise ValueError("position market value cannot be negative")
             normalized[key] = normalized.get(key, 0.0) + market_value
         return normalized
+
+
+class GuardrailContext(BaseModel):
+    """Trusted facts supplied to the shared buy-ticket guardrails."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    portfolio: PortfolioState
+    itc_risk_score: float = Field(ge=0.0, le=1.0)
+    annual_margin_rate: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        allow_inf_nan=False,
+    )

--- a/fin-guru/agents/strategy-advisor.md
+++ b/fin-guru/agents/strategy-advisor.md
@@ -67,7 +67,7 @@ uv run python -m src.analysis.factors_cli TICKER --days 252 --benchmark SPY Fama
 
 uv run python -m src.utils.market_data TICKER [TICKER2 ...] Real-time market prices for quick validation Current market prices for quick validation
 
-Advisory-only ITC Risk overlay for supported tickers. Use it to enrich timing and risk notes when data is available, but never block buy-ticket generation.
+ITC Risk overlay for supported tickers. Enrich timing and risk notes with it, and note that buy-ticket generation treats the Layer 3 score as a hard cap: a missing, not-run, or failed Layer 3 result blocks the ticket.
 
 TSLA, AAPL, MSTR, NFLX, SP500, DXY, XAUUSD, XAGUSD, XPDUSD, PL, HG, NICKEL BTC, ETH, BNB, SOL, XRP, ADA, DOGE, LINK, AVAX, DOT, SHIB, LTC, AAVE, ATOM, POL, ALGO, HBAR, RENDER, VET, TRX, TON, SUI, XLM, XMR, XTZ, SKY, BTC.D, TOTAL, TOTAL6
 

--- a/fin-guru/data/definitions.md
+++ b/fin-guru/data/definitions.md
@@ -646,10 +646,10 @@ remaining_cash  =  current_cash − deployment_amount
 ### 16.2 Concentration
 
 ```
-new_pct  =  (existing_value + deployment[ticker]) / (portfolio_value + deployment_total)
+new_pct  =  (existing_value + deployment[ticker]) / equity_nav_pre_borrow
 ```
 
-Warn if `new_pct > 0.30`.
+The denominator is the pre-borrow equity NAV. Margin-funded deployment never inflates it. Block if `new_pct > 0.30`, and block when equity NAV is missing or non-positive.
 
 ### 16.3 Margin coverage
 

--- a/fin-guru/tasks/create-doc.md
+++ b/fin-guru/tasks/create-doc.md
@@ -35,7 +35,7 @@ When creating a buy ticket, do not draft from vague strategy text alone. Confirm
 6. Risk notes relevant to sizing, concentration, volatility, or margin
 7. Sources & assumptions block plus the full disclaimer block
 
-ITC risk is advisory-only. For supported tickers, include an ITC advisory section only when upstream analysis provided a materially elevated signal. Missing ITC data must never block ticket creation.
+ITC risk is a hard cap for supported tickers. The cap reads only successful Layer 3 output, never model-returned fields; a missing, not-run, or failed Layer 3 result blocks ticket generation. Include an ITC advisory section when the Layer 3 signal is materially elevated.
 
 ## Interactive Section Processing
 

--- a/tests/test_buy_ticket_retry.py
+++ b/tests/test_buy_ticket_retry.py
@@ -1,0 +1,123 @@
+"""Regression tests for idempotent buy-ticket draft notification retries."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from buy_ticket_agent.config import NotificationConfig
+from buy_ticket_agent.main import main
+from buy_ticket_agent.notifier import NotificationResult
+from buy_ticket_agent.pipeline import CliEnvelope, SmokeResult, run_smoke
+from buy_ticket_agent.secrets import SecretAccessError
+
+
+def _configure_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("FIN_GURU_DATA_ROOT", str(tmp_path))
+    monkeypatch.setenv("BUY_TICKET_TRIGGER_SOURCE", "simplefin_deposit")
+    monkeypatch.setenv("BUY_TICKET_TRIGGER_TRANSACTION_KEY", "transaction-key")
+
+
+def test_notification_retry_reuses_persisted_draft(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same trigger retries delivery without regenerating its draft."""
+    _configure_trigger(monkeypatch, tmp_path)
+    fixed_now = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
+    cli_result = CliEnvelope(
+        command=["python", "itc_risk_cli.py"],
+        status="succeeded",
+        returncode=0,
+        stdout_chars=10,
+        stderr_chars=0,
+    )
+    notification_config = NotificationConfig(
+        server_url="https://ntfy.example.test",
+        topic="topic",
+        source="env",
+    )
+    notifications = [
+        NotificationResult(status="failed", source="env", error="Timeout"),
+        NotificationResult(status="sent", source="env"),
+    ]
+
+    with (
+        patch(
+            "buy_ticket_agent.pipeline.resolve_notification_config",
+            return_value=notification_config,
+        ),
+        patch(
+            "buy_ticket_agent.pipeline.run_layer3_smoke_cli",
+            return_value=cli_result,
+        ) as layer3,
+        patch(
+            "buy_ticket_agent.pipeline.push_ticket_preview",
+            side_effect=notifications,
+        ) as notify,
+        patch("buy_ticket_agent.pipeline._utc_now", return_value=fixed_now),
+    ):
+        first = run_smoke()
+        second = run_smoke()
+
+    assert first.run_id == second.run_id
+    assert first.ticket_id == second.ticket_id
+    assert first.draft_path == second.draft_path
+    assert first.persistence.status == "created"
+    assert second.persistence.status == "reused"
+    assert first.status == second.status == "completed"
+    assert first.notification.status == "failed"
+    assert second.notification.status == "sent"
+    assert layer3.call_count == 1
+    assert notify.call_count == 2
+    assert len(list((tmp_path / "tickets" / "auto-drafts").glob("*.json"))) == 1
+
+    with sqlite3.connect(tmp_path / "auto-tickets" / "state.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM tickets").fetchone()[0] == 1
+
+
+def test_main_retries_failed_notification_after_persistence(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Persisted-but-unnotified results remain observable and retryable."""
+    result = SmokeResult(
+        run_id="run-1",
+        ticket_id="ticket-1",
+        status="completed",
+        draft_path="draft.json",
+        log_path="log.json",
+        state_db="state.db",
+        notification=NotificationResult(status="failed", source="env"),
+    )
+
+    with patch("buy_ticket_agent.main.run_smoke_for_cli", return_value=result):
+        exit_code = main(["--smoke"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "completed"
+    assert payload["notification"]["status"] == "failed"
+    assert exit_code == 1
+
+
+def test_main_uses_repository_logger_for_secret_diagnostics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Secret failures do not emit ad hoc print diagnostics."""
+    with patch(
+        "buy_ticket_agent.main.run_smoke_for_cli",
+        side_effect=SecretAccessError("bws unavailable"),
+    ):
+        exit_code = main(["--smoke"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Secret access blocker" not in captured.err

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
+import pytest
+
 from buy_ticket_agent.guardrails import check
-from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState, TicketAllocation
+from buy_ticket_agent.ticket_models import (
+    GuardrailContext,
+    PortfolioState,
+    TicketAllocation,
+    TicketProposal,
+)
+
+_UNSET = object()
 
 
 def _ticket_with_allocation(
     ticker: str,
     weight: float,
     amount: float,
-) -> BuyTicket:
-    return BuyTicket(
+) -> TicketProposal:
+    return TicketProposal(
         strategy_name="AOJ-461 acceptance ticket",
         generated_on="2026-06-08",
         generated_by="strategy-advisor",
@@ -20,8 +29,6 @@ def _ticket_with_allocation(
         cash_available=100000.0,
         remaining_cash_buffer=100000.0 - amount,
         price_snapshot_as_of="2026-06-08T15:00:00Z",
-        itc_applicability="supported",
-        itc_risk_score=0.42,
         allocations=[
             TicketAllocation(
                 ticker=ticker,
@@ -45,6 +52,21 @@ def _ticket_with_allocation(
     )
 
 
+def _context(
+    portfolio: PortfolioState | dict,
+    *,
+    itc_risk_score: float = 0.42,
+    annual_margin_rate: float | None | object = _UNSET,
+) -> GuardrailContext:
+    context = {
+        "portfolio": PortfolioState.model_validate(portfolio),
+        "itc_risk_score": itc_risk_score,
+    }
+    if annual_margin_rate is not _UNSET:
+        context["annual_margin_rate"] = annual_margin_rate
+    return GuardrailContext.model_validate(context)
+
+
 def test_check_rejects_ticket_proposing_thirty_five_percent_concentration() -> None:
     """A ticket proposing 35% concentration is hard-blocked after LLM output."""
     ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=35000.0)
@@ -57,7 +79,7 @@ def test_check_rejects_ticket_proposing_thirty_five_percent_concentration() -> N
         context_date="2026-06-08",
     )
 
-    result = check(ticket, portfolio)
+    result = check(ticket, _context(portfolio))
 
     assert result.status == "blocked"
     assert result.advisory_block == "concentration>30%"
@@ -76,10 +98,49 @@ def test_check_rejects_cash_funded_deployment_above_concentration_limit() -> Non
         context_date="2026-06-08",
     )
 
-    result = check(ticket, portfolio)
+    result = check(ticket, _context(portfolio))
 
     assert result.status == "blocked"
     assert result.advisory_block == "concentration>30%"
+
+
+def test_check_rejects_margin_funded_concentration_against_pre_borrow_nav() -> None:
+    """Borrowed deployment cannot increase the concentration denominator."""
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=31000.0)
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=0.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=200.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, _context(portfolio))
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "concentration>30%"
+
+
+@pytest.mark.parametrize("portfolio_value", [None, 0.0, -1.0])
+def test_check_rejects_unavailable_pre_borrow_equity_nav(
+    portfolio_value: float | None,
+) -> None:
+    """Missing and non-positive pre-borrow equity NAV fail closed."""
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=1000.0)
+    portfolio = {
+        "portfolio_value": portfolio_value,
+        "cash_available": 1000.0,
+        "monthly_dividend_income": 500.0,
+        "monthly_margin_interest": 200.0,
+        "current_positions": {},
+        "context_date": "2026-06-08",
+    }
+
+    result = check(ticket, _context(portfolio))
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "equity_nav_unavailable"
 
 
 def test_check_sums_duplicate_normalized_positions_before_concentration() -> None:
@@ -94,7 +155,7 @@ def test_check_sums_duplicate_normalized_positions_before_concentration() -> Non
         context_date="2026-06-08",
     )
 
-    result = check(ticket, portfolio)
+    result = check(ticket, _context(portfolio))
 
     assert result.status == "blocked"
     assert result.advisory_block == "concentration>30%"
@@ -102,9 +163,7 @@ def test_check_sums_duplicate_normalized_positions_before_concentration() -> Non
 
 def test_check_accepts_ticket_within_all_hard_limits() -> None:
     """A ticket within every hard threshold is accepted without violations."""
-    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=20000.0).model_copy(
-        update={"advisory_block": "llm-authored advisory"}
-    )
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=20000.0)
     portfolio = PortfolioState(
         portfolio_value=100000.0,
         cash_available=20000.0,
@@ -114,7 +173,7 @@ def test_check_accepts_ticket_within_all_hard_limits() -> None:
         context_date="2026-06-08",
     )
 
-    result = check(ticket, portfolio)
+    result = check(ticket, _context(portfolio))
 
     assert result.status == "accepted"
     assert result.advisory_block is None
@@ -134,18 +193,96 @@ def test_check_rejects_ticket_when_margin_coverage_is_below_two_times() -> None:
         context_date="2026-06-08",
     )
 
-    result = check(ticket, portfolio)
+    result = check(ticket, _context(portfolio))
 
     assert result.status == "blocked"
     assert result.advisory_block == "coverage<2x"
     assert result.ticket.advisory_block == "coverage<2x"
 
 
+def test_check_rejects_new_borrowing_when_margin_rate_is_missing() -> None:
+    """Projected borrowing fails closed without an authoritative annual rate."""
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=20000.0)
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=0.0,
+        monthly_dividend_income=500.0,
+        monthly_margin_interest=0.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(ticket, _context(portfolio))
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "margin_rate_unavailable"
+
+
+def test_check_projects_interest_when_current_margin_interest_is_zero() -> None:
+    """New borrowing is covered even when the current interest bill is zero."""
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=20000.0)
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=0.0,
+        monthly_dividend_income=300.0,
+        monthly_margin_interest=0.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(
+        ticket,
+        _context(portfolio, annual_margin_rate=0.12),
+    )
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "coverage<2x"
+
+
+def test_check_accepts_healthy_projected_margin_coverage() -> None:
+    """Dividend income at 2x projected post-ticket interest remains healthy."""
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=20000.0)
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=0.0,
+        monthly_dividend_income=600.0,
+        monthly_margin_interest=100.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(
+        ticket,
+        _context(portfolio, annual_margin_rate=0.12),
+    )
+
+    assert result.status == "accepted"
+
+
+def test_check_rejects_degraded_projected_margin_coverage() -> None:
+    """Projected interest that drops coverage below 2x is hard-blocked."""
+    ticket = _ticket_with_allocation("SPY", weight=1.0, amount=10000.0)
+    portfolio = PortfolioState(
+        portfolio_value=100000.0,
+        cash_available=0.0,
+        monthly_dividend_income=400.0,
+        monthly_margin_interest=150.0,
+        current_positions={},
+        context_date="2026-06-08",
+    )
+
+    result = check(
+        ticket,
+        _context(portfolio, annual_margin_rate=0.12),
+    )
+
+    assert result.status == "blocked"
+    assert result.advisory_block == "coverage<2x"
+
+
 def test_check_rejects_ticket_when_itc_risk_is_at_hard_limit() -> None:
     """ITC risk must stay below 0.7 after the LLM response."""
-    ticket = _ticket_with_allocation("SPY", weight=0.20, amount=20000.0).model_copy(
-        update={"itc_risk_score": 0.70}
-    )
+    ticket = _ticket_with_allocation("SPY", weight=0.20, amount=20000.0)
     portfolio = PortfolioState(
         portfolio_value=100000.0,
         cash_available=100000.0,
@@ -155,77 +292,8 @@ def test_check_rejects_ticket_when_itc_risk_is_at_hard_limit() -> None:
         context_date="2026-06-08",
     )
 
-    result = check(ticket, portfolio)
+    result = check(ticket, _context(portfolio, itc_risk_score=0.70))
 
     assert result.status == "blocked"
     assert result.advisory_block == "itc_risk>=0.7"
     assert result.ticket.advisory_block == "itc_risk>=0.7"
-
-
-def test_check_rejects_ticket_when_itc_is_supported_but_score_is_missing() -> None:
-    """ITC-supported tickets require a risk score; a None score is hard-blocked.
-
-    Realistic trigger: the ITC CLI fails during Layer 3 pipeline execution so the
-    bundle carries itc.data=null.  The LLM faithfully emits
-    itc_applicability='supported' (tradfi asset) but itc_risk_score=null because no
-    score was available.  Without this guard the guardrail would silently pass.
-    """
-    ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=20000.0).model_copy(
-        update={"itc_risk_score": None}
-    )
-    # _ticket_with_allocation always sets itc_applicability="supported".
-    assert ticket.itc_applicability == "supported"
-    portfolio = PortfolioState(
-        portfolio_value=100000.0,
-        cash_available=100000.0,
-        monthly_dividend_income=500.0,
-        monthly_margin_interest=200.0,
-        current_positions={},
-        context_date="2026-06-08",
-    )
-
-    result = check(ticket, portfolio)
-
-    assert result.status == "blocked"
-    assert result.advisory_block == "itc_risk_score_missing"
-    assert result.ticket.advisory_block == "itc_risk_score_missing"
-
-
-def test_check_accepts_ticket_when_itc_is_not_supported_and_score_is_missing() -> None:
-    """Non-supported ITC applicability with a None score is not a violation."""
-    ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=20000.0).model_copy(
-        update={"itc_applicability": "not-run", "itc_risk_score": None}
-    )
-    portfolio = PortfolioState(
-        portfolio_value=100000.0,
-        cash_available=100000.0,
-        monthly_dividend_income=500.0,
-        monthly_margin_interest=200.0,
-        current_positions={},
-        context_date="2026-06-08",
-    )
-
-    result = check(ticket, portfolio)
-
-    assert result.status == "accepted"
-    assert result.advisory_block is None
-
-
-def test_check_accepts_ticket_when_itc_is_unsupported_and_score_is_missing() -> None:
-    """Unsupported ITC applicability with a None score is not a violation."""
-    ticket = _ticket_with_allocation("TSLA", weight=1.0, amount=20000.0).model_copy(
-        update={"itc_applicability": "unsupported", "itc_risk_score": None}
-    )
-    portfolio = PortfolioState(
-        portfolio_value=100000.0,
-        cash_available=100000.0,
-        monthly_dividend_income=500.0,
-        monthly_margin_interest=200.0,
-        current_positions={},
-        context_date="2026-06-08",
-    )
-
-    result = check(ticket, portfolio)
-
-    assert result.status == "accepted"
-    assert result.advisory_block is None

--- a/tests/test_ticket_generator.py
+++ b/tests/test_ticket_generator.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from buy_ticket_agent import config
 from buy_ticket_agent.ticket_generator import generate
 from buy_ticket_agent.ticket_models import BuyTicket, PortfolioState
+from src.config.instance_paths import InstancePaths
 
 
 def _ticket_payload() -> dict[str, Any]:
@@ -87,7 +90,13 @@ def _layer3_bundle() -> dict[str, Any]:
         "itc": {
             **tool_result,
             "key": "itc",
-            "data": {"symbol": "TSLA", "current_risk_score": 0.42},
+            "data": {
+                "symbol": "TSLA",
+                "universe": "tradfi",
+                "current_risk_score": 0.42,
+                "risk_bands": [],
+                "timestamp": "2026-06-08T15:00:00Z",
+            },
         },
         "risk": {**tool_result, "key": "risk"},
         "mom": {**tool_result, "key": "mom"},
@@ -185,6 +194,8 @@ def test_generate_calls_claude_with_prompt_cache_and_returns_valid_ticket() -> N
     input_schema = call["tools"][0]["input_schema"]
     assert "advisory_block" not in input_schema["properties"]
     assert "advisory_block" not in input_schema.get("required", [])
+    assert "itc_applicability" not in input_schema["properties"]
+    assert "itc_risk_score" not in input_schema["properties"]
     assert any(
         block.get("cache_control", {}).get("type") == "ephemeral"
         for block in call["system"]
@@ -224,3 +235,70 @@ def test_generate_clears_llm_authored_advisory_block_on_accepted_ticket() -> Non
     assert result.guardrails.status == "accepted"
     assert result.guardrails.advisory_block is None
     assert result.ticket.advisory_block is None
+
+
+def test_generate_uses_layer3_itc_score_over_understated_model_score() -> None:
+    """A lower model-authored ITC score cannot bypass the Layer 3 hard cap."""
+    bundle = _layer3_bundle()
+    bundle["itc"]["data"]["current_risk_score"] = 0.72
+    payload = {**_ticket_payload(), "itc_risk_score": 0.01}
+    client = FakeAnthropicClient(cache_reads=[0], tool_input=payload)
+
+    result = generate(bundle, _portfolio_state(), client=client)
+
+    assert result.guardrails.status == "blocked"
+    assert result.guardrails.advisory_block == "itc_risk>=0.7"
+    assert result.ticket.itc_risk_score == 0.72
+
+
+@pytest.mark.parametrize("itc_state", ["missing", "not-run", "failed"])
+def test_generate_blocks_unavailable_layer3_itc_before_model_call(
+    itc_state: str,
+) -> None:
+    """Only a successful authoritative Layer 3 ITC result permits generation."""
+    bundle = _layer3_bundle()
+    if itc_state == "missing":
+        del bundle["itc"]
+    else:
+        bundle["itc"]["status"] = itc_state
+    client = FakeAnthropicClient(cache_reads=[0])
+
+    with pytest.raises(ValueError, match="Layer 3 ITC"):
+        generate(bundle, _portfolio_state(), client=client)
+
+    assert client.messages.calls == []
+
+
+def test_resolve_annual_margin_rate_prefers_decimal_instance_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The instance environment has one decimal-first margin-rate adapter."""
+    monkeypatch.delenv("FG_MARGIN_INTEREST_RATE_DECIMAL", raising=False)
+    monkeypatch.delenv("FG_MARGIN_INTEREST_RATE", raising=False)
+    (tmp_path / ".env").write_text(
+        "FG_MARGIN_INTEREST_RATE_DECIMAL=0.12\nFG_MARGIN_INTEREST_RATE=99%\n"
+    )
+
+    rate = config.resolve_annual_margin_rate(InstancePaths(root=tmp_path))
+
+    assert rate == pytest.approx(0.12)
+
+
+def test_generate_applies_configured_rate_to_projected_interest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production generator wires configured rate policy into guardrails."""
+    monkeypatch.setenv("FG_MARGIN_INTEREST_RATE_DECIMAL", "0.12")
+    portfolio = _portfolio_state().model_copy(
+        update={
+            "cash_available": 0.0,
+            "monthly_dividend_income": 100.0,
+            "monthly_margin_interest": 0.0,
+        }
+    )
+    client = FakeAnthropicClient(cache_reads=[0])
+
+    result = generate(_layer3_bundle(), portfolio, client=client)
+
+    assert result.guardrails.advisory_block == "coverage<2x"


### PR DESCRIPTION
## Problem

Four guardrail defects in `buy_ticket_agent`. The concentration check could divide by a margin-inflated denominator and let a non-positive NAV pass open (#102). The ITC hard cap trusted model-returned fields instead of Layer 3 (#104). Margin coverage ignored the borrowing the ticket itself would add (#105). A persisted draft whose notification failed was reported as a failed run, so a retry could write a second draft (#107).

## Fix

- `GuardrailContext` carries the trusted inputs (portfolio, Layer 3 ITC score, annual margin rate); the model's `TicketProposal` has no authority over any of them.
- Concentration divides by the pre-borrow equity NAV and blocks on `equity_nav_unavailable` when NAV is missing or non-positive.
- Coverage adds projected interest on `max(deployment - cash, 0)` at the configured rate (`FG_MARGIN_INTEREST_RATE_DECIMAL` or `FG_MARGIN_INTEREST_RATE` from the instance env via `resolve_annual_margin_rate`). A ticket that would borrow with no configured rate blocks on `margin_rate_unavailable`.
- Missing, not-run, or failed Layer 3 blocks ticket generation.
- Trigger identity is stable across retries and an existing draft is reused. `NotificationResult.status` is the literal union sent/skipped/failed, and the CLI exits 1 on a failed notification while the persisted draft stands. Print diagnostics are now structured log events.
- Three fin-guru docs that described ITC as advisory-only and the old concentration denominator now match the guardrail.
- The pre-commit mypy hook gains `anthropic`, the same one-line change as #156, because the commit gate rejected the buy_ticket_agent files without it.

## Evidence

Each defect was seen red first: `assert result.status == "blocked"` received `accepted` (guardrails and generator), `DID NOT RAISE` for the missing-rate path, differing run ids on retry, and exit code 0 on a failed notification. Focused run 27 passed. Ruff, mypy on `src` and `buy_ticket_agent`, and the non-integration suite (1127 passed, coverage 82.22%) are clean.

Closes #102, closes #104, closes #105, closes #107.

Changes made by gpt-5.6-sol (Codex, herdr worker) with review and commit by Claude Fable 5.1 in Claude Code.