### PR TITLE
ci(simplefin-sync): make bun typecheck resolve @types/bun and run it in quality gates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -132,6 +132,21 @@ jobs:
           head -80 pyinstrument-report.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "Profiling step completed with caveats — see logs."
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
+  simplefin-sync-typecheck:
+    name: simplefin-sync typecheck + tests (bun)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/simplefin-sync
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun test
+
   dead-flag-detection:
     name: Dead feature-flag detection
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -140,6 +140,8 @@ jobs:
         working-directory: apps/simplefin-sync
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/apps/simplefin-sync/src/trigger.test.ts
+++ b/apps/simplefin-sync/src/trigger.test.ts
@@ -338,7 +338,7 @@ describe("SimpleFIN deposit trigger", () => {
       transactionKey: "transaction-key",
       sourceAccountKey: "source-account-key",
       posted: 1_779_984_000,
-      pending: false,
+      pending: false as const,
     };
 
     const env = buildBuyTicketEnv(detection, {

--- a/apps/simplefin-sync/tsconfig.json
+++ b/apps/simplefin-sync/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["bun-types"]
+    "types": ["bun"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Problem

`bun run typecheck` in `apps/simplefin-sync` failed on main with TS2688 because `tsconfig.json` named `bun-types` while the workspace installs `@types/bun`. No CI job ran the typecheck, so the break was invisible (#158).

## Fix

- `types` now points at `bun`, the name `@types/bun` registers.
- New `simplefin-sync-typecheck` job in quality-gates: frozen-lockfile install, `bun run typecheck`, `bun test`.
- The first real typecheck surfaced one latent error from #154: a test fixture typed `pending` as `boolean` where `DepositDetection` now requires the literal `false`. Narrowed with `as const`.

Local: typecheck exit 0, bun test 13 pass. actionlint reports only the pre-existing SC2129 style notes.

Closes #158.

Changes made by Claude Fable 5.1 in Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated quality checks for the SimpleFIN Sync application, including type checking and test execution.

* **Chores**
  * Updated TypeScript configuration to use the current Bun type definitions.
  * Improved test fixture type accuracy without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->