### PR TITLE
ci(release): match release-please tags to the repo's vX.Y.Z tag format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "python",
       "package-name": "family-office",
+      "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## Problem

The first release-please run with the new token opened #164, but its changelog has 172 entries reaching back to the first commit. The run log shows why: `Found release tag with component '', but not configured in manifest`. release-please searched for `family-office-v2.2.0`; the repo's tags are `v2.2.0`, `v2.1.0`, `v2.0.0`, and v2.2.0 is already a published release.

## Fix

Set `include-component-in-tag: false` in `release-please-config.json` so tags are `vX.Y.Z`. On the next push to main, release-please will find `v2.2.0` and rebuild #164 with only the commits since it.

Refs #112.

Changes made by Claude Fable 5.1 in Claude Code.